### PR TITLE
feat: add iPad resizable split layout

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -12,6 +12,7 @@ export default function appConfig(_context: ConfigContext): ExpoConfig {
     ios: {
       icon: "./assets/images/icon.png",
       bundleIdentifier: "com.gronstudio.codexrelay",
+      supportsTablet: true,
       infoPlist: {
         NSAppTransportSecurity: {
           NSAllowsArbitraryLoads: true,
@@ -20,6 +21,12 @@ export default function appConfig(_context: ConfigContext): ExpoConfig {
         ITSAppUsesNonExemptEncryption: false,
         NSLocalNetworkUsageDescription:
           "Codex Relay uses the local network to connect this device to the Codex Relay server running on your computer.",
+        "UISupportedInterfaceOrientations~ipad": [
+          "UIInterfaceOrientationPortrait",
+          "UIInterfaceOrientationPortraitUpsideDown",
+          "UIInterfaceOrientationLandscapeLeft",
+          "UIInterfaceOrientationLandscapeRight",
+        ],
       },
     },
     android: {

--- a/apps/mobile/src/app/(drawer)/_layout.tsx
+++ b/apps/mobile/src/app/(drawer)/_layout.tsx
@@ -1,13 +1,59 @@
 import { Drawer } from "expo-router/drawer";
+import { Pressable, useWindowDimensions, View } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { StyleSheet } from "react-native-unistyles";
 
 import { ThreadDrawerContent } from "@/components/chat/ThreadDrawerContent";
+import {
+  EXPANDED_DRAWER_BREAKPOINT,
+  IpadSplitLayoutProvider,
+  useIpadSplitLayout,
+} from "@/components/chat/ipad-split-layout";
+import { Icon, type AppIconName } from "@/components/ui/icon";
+import { Colors } from "@/constants/theme";
+import { hapticMediumImpact } from "@/lib/haptics";
+
+const COMPACT_DRAWER_WIDTH = 320;
+const COLLAPSED_DRAWER_WIDTH = 52;
 
 export default function DrawerLayout() {
   return (
+    <IpadSplitLayoutProvider>
+      <DrawerLayoutContent />
+    </IpadSplitLayoutProvider>
+  );
+}
+
+function DrawerLayoutContent() {
+  const { width } = useWindowDimensions();
+  const { beginSidebarResize, isSidebarVisible, resizeSidebar, setSidebarVisible, sidebarWidth } =
+    useIpadSplitLayout();
+  const usesExpandedDrawer = width >= EXPANDED_DRAWER_BREAKPOINT;
+  const showsExpandedDrawer = usesExpandedDrawer && isSidebarVisible;
+  const showsCollapsedRail = usesExpandedDrawer && !isSidebarVisible;
+
+  function expandSidebar() {
+    setSidebarVisible(true);
+    hapticMediumImpact();
+  }
+
+  return (
     <Drawer
-      drawerContent={(props) => <ThreadDrawerContent {...props} />}
+      drawerContent={(props) =>
+        showsExpandedDrawer || !usesExpandedDrawer ? (
+          <ThreadDrawerContent
+            isPermanent={showsExpandedDrawer}
+            showResizeHandle={showsExpandedDrawer}
+            onSidebarResize={resizeSidebar}
+            onSidebarResizeStart={beginSidebarResize}
+            {...props}
+          />
+        ) : showsCollapsedRail ? (
+          <CollapsedThreadSidebarRail onExpand={expandSidebar} />
+        ) : null
+      }
       screenOptions={{
-        drawerType: "front",
+        drawerType: usesExpandedDrawer ? "permanent" : "front",
         headerShown: false,
         swipeEnabled: false,
         sceneStyle: {
@@ -16,10 +62,15 @@ export default function DrawerLayout() {
         drawerStyle: {
           backgroundColor: "#202222",
           borderRightColor: "rgba(255, 255, 255, 0.08)",
-          borderRightWidth: 1,
-          width: 320,
+          borderRightWidth: usesExpandedDrawer ? 1 : 0,
+          overflow: showsExpandedDrawer ? "visible" : "hidden",
+          width: usesExpandedDrawer
+            ? showsExpandedDrawer
+              ? sidebarWidth
+              : COLLAPSED_DRAWER_WIDTH
+            : COMPACT_DRAWER_WIDTH,
         },
-        overlayColor: "rgba(0, 0, 0, 0.28)",
+        overlayColor: usesExpandedDrawer ? "transparent" : "rgba(0, 0, 0, 0.28)",
       }}
     >
       <Drawer.Screen
@@ -41,3 +92,64 @@ export default function DrawerLayout() {
     </Drawer>
   );
 }
+
+function CollapsedThreadSidebarRail({ onExpand }: { onExpand: () => void }) {
+  return (
+    <SafeAreaView edges={["top", "bottom"]} style={styles.collapsedRail}>
+      <View style={styles.collapsedRailTop}>
+        <CollapsedRailButton icon="sidebarShow" label="Show threads" onPress={onExpand} />
+        <CollapsedRailButton icon="search" label="Open thread search" onPress={onExpand} />
+        <CollapsedRailButton icon="newChat" label="Open new chat" onPress={onExpand} />
+      </View>
+      <CollapsedRailButton icon="settings" label="Open settings" onPress={onExpand} />
+    </SafeAreaView>
+  );
+}
+
+function CollapsedRailButton({
+  icon,
+  label,
+  onPress,
+}: {
+  icon: AppIconName;
+  label: string;
+  onPress: () => void;
+}) {
+  return (
+    <Pressable
+      accessibilityLabel={label}
+      accessibilityRole="button"
+      hitSlop={6}
+      onPress={onPress}
+      style={({ pressed }) => [styles.collapsedRailButton, pressed && styles.pressed]}
+    >
+      <Icon name={icon} size={17} tintColor={Colors.dark.textSecondary} />
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  collapsedRail: {
+    alignItems: "center",
+    backgroundColor: "#202222",
+    flex: 1,
+    justifyContent: "space-between",
+    paddingBottom: 10,
+    paddingTop: 10,
+    width: COLLAPSED_DRAWER_WIDTH,
+  },
+  collapsedRailButton: {
+    alignItems: "center",
+    borderRadius: 9,
+    height: 36,
+    justifyContent: "center",
+    width: 36,
+  },
+  collapsedRailTop: {
+    gap: 8,
+  },
+  pressed: {
+    backgroundColor: "rgba(255, 255, 255, 0.08)",
+    opacity: 0.72,
+  },
+});

--- a/apps/mobile/src/components/chat/ChatScreen.tsx
+++ b/apps/mobile/src/components/chat/ChatScreen.tsx
@@ -30,7 +30,18 @@ import {
 import * as ImagePicker from "expo-image-picker";
 import { useFocusEffect, useNavigation } from "expo-router";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Alert, AppState, Keyboard, Linking, Modal, Pressable, View } from "react-native";
+import {
+  Alert,
+  AppState,
+  Keyboard,
+  Linking,
+  Modal,
+  Pressable,
+  type LayoutChangeEvent,
+  useWindowDimensions,
+  View,
+} from "react-native";
+import { Gesture, GestureDetector } from "react-native-gesture-handler";
 import { KeyboardController } from "react-native-keyboard-controller";
 import PagerView from "react-native-pager-view";
 import Animated, { LinearTransition } from "react-native-reanimated";
@@ -130,6 +141,11 @@ import { addWorkspacePreviewTab } from "@/state/workspace-preview-store";
 import { ChatControls } from "./ChatControls";
 import { ChatShell } from "./ChatShell";
 import { ConnectionBanner } from "./ConnectionBanner";
+import {
+  EXPANDED_DRAWER_BREAKPOINT,
+  THREE_PANE_LAYOUT_BREAKPOINT,
+  useIpadSplitLayout,
+} from "./ipad-split-layout";
 import { WorkspacePreviewSurface } from "./WorkspacePreviewSurface";
 import type { WorkspaceMarkdownPreviewTarget } from "./workspace-preview/markdown-target";
 
@@ -142,12 +158,18 @@ const STREAM_STALL_RECONNECT_MS = 45_000;
 const STREAM_WATCHDOG_INTERVAL_MS = 10_000;
 const SCANNER_TO_APPROVAL_SHEET_DELAY_MS = 450;
 const COPY_TOAST_VISIBLE_MS = 1800;
+const PREVIEW_RESIZE_HANDLE_WIDTH = 14;
+const DEFAULT_PREVIEW_PANE_WIDTH = 540;
+const MIN_CHAT_PANE_WIDTH = 420;
+const MIN_PREVIEW_PANE_WIDTH = 360;
 const EMPTY_SKILLS: AgentSkill[] = [];
 const EMPTY_THREADS: ThreadSummary[] = [];
 let isHandlingPairingLink = false;
 let lastHandledPairingUrl: string | undefined;
 
 export function ChatScreen() {
+  const { width } = useWindowDimensions();
+  const { isSidebarVisible, toggleSidebar } = useIpadSplitLayout();
   const [pasteApprovalCode, setPasteApprovalCode] = useState<string | undefined>(undefined);
   const [pasteApprovalServerUrl, setPasteApprovalServerUrl] = useState<string | undefined>(
     undefined,
@@ -174,10 +196,15 @@ export function ChatScreen() {
   >(undefined);
   const [isHandlingScan, setHandlingScan] = useState(false);
   const [activePagerPage, setActivePagerPage] = useState(0);
+  const [isWidePreviewVisible, setWidePreviewVisible] = useState(true);
+  const [wideLayoutWidth, setWideLayoutWidth] = useState(0);
+  const [previewPaneWidth, setPreviewPaneWidth] = useState(DEFAULT_PREVIEW_PANE_WIDTH);
   const [scannerMessage, setScannerMessage] = useState("Point the camera at the connection QR.");
   const copyToastIdRef = useRef(0);
   const [copyToast, setCopyToast] = useState<{ id: number } | undefined>(undefined);
   const [cameraPermission, requestCameraPermission] = useCameraPermissions();
+  const usesExpandedSidebar = width >= EXPANDED_DRAWER_BREAKPOINT;
+  const usesWideLayout = width >= THREE_PANE_LAYOUT_BREAKPOINT;
   const drawerNavigation = useNavigation<{
     openDrawer?: () => void;
   }>();
@@ -319,6 +346,7 @@ export function ChatScreen() {
   const isAttachingImagesRef = useRef(false);
   const isHandlingScanRef = useRef(false);
   const isModernScannerOpenRef = useRef(false);
+  const previewResizeStartWidthRef = useRef(DEFAULT_PREVIEW_PANE_WIDTH);
   const scanPairingGenerationRef = useRef(0);
   const closeStreamRef = useRef<(() => void) | undefined>(undefined);
   const refreshPromiseRef = useRef<Promise<void> | undefined>(undefined);
@@ -950,11 +978,16 @@ export function ChatScreen() {
       dismissKeyboardForWorkspacePreview();
       addWorkspacePreviewTab(workspacePath, previewRequest.tab);
       hapticMediumImpact();
-      requestAnimationFrame(() => {
-        showPagerPage(1);
-      });
+      if (usesWideLayout) {
+        setWidePreviewVisible(true);
+        setActivePagerPage(1);
+      } else {
+        requestAnimationFrame(() => {
+          showPagerPage(1);
+        });
+      }
     },
-    [activeThreadId, activeWorkspacePath, showPagerPage],
+    [activeThreadId, activeWorkspacePath, showPagerPage, usesWideLayout],
   );
 
   const openMarkdownAttachmentPreview = useCallback(
@@ -971,8 +1004,13 @@ export function ChatScreen() {
 
   const closeWorkspacePreview = useCallback(() => {
     hapticSelection();
+    if (usesWideLayout) {
+      setWidePreviewVisible(false);
+      setActivePagerPage(0);
+      return;
+    }
     showPagerPage(0);
-  }, [showPagerPage]);
+  }, [showPagerPage, usesWideLayout]);
 
   const checkoutBranch = useCallback(
     async (branch: string) => {
@@ -1983,132 +2021,246 @@ export function ChatScreen() {
     hapticMediumImpact();
   }
 
+  function toggleThreadSidebar() {
+    Keyboard.dismiss();
+    toggleSidebar();
+    hapticMediumImpact();
+  }
+
+  function toggleWorkspacePreview() {
+    Keyboard.dismiss();
+    const nextVisible = !isWidePreviewVisible;
+    setWidePreviewVisible(nextVisible);
+    setActivePagerPage(nextVisible ? 1 : 0);
+    hapticMediumImpact();
+  }
+
+  const onWideLayout = useCallback((event: LayoutChangeEvent) => {
+    const nextWidth = Math.round(event.nativeEvent.layout.width);
+    setWideLayoutWidth((current) => (current === nextWidth ? current : nextWidth));
+  }, []);
+
+  useEffect(() => {
+    if (wideLayoutWidth <= 0) {
+      return;
+    }
+
+    setPreviewPaneWidth((current) => clampPreviewPaneWidth(current, wideLayoutWidth));
+  }, [wideLayoutWidth]);
+
+  const clampedPreviewPaneWidth = clampPreviewPaneWidth(previewPaneWidth, wideLayoutWidth);
+  const showsWidePreviewPane = usesWideLayout && isWidePreviewVisible;
+  const wideChatPaneWidth =
+    wideLayoutWidth > 0
+      ? Math.max(
+          MIN_CHAT_PANE_WIDTH,
+          wideLayoutWidth -
+            (showsWidePreviewPane ? clampedPreviewPaneWidth + PREVIEW_RESIZE_HANDLE_WIDTH : 0),
+        )
+      : 0;
+
+  const beginPreviewResize = useCallback(() => {
+    previewResizeStartWidthRef.current = clampedPreviewPaneWidth;
+    hapticSelection();
+  }, [clampedPreviewPaneWidth]);
+
+  const resizePreview = useCallback(
+    (translationX: number) => {
+      setPreviewPaneWidth(
+        clampPreviewPaneWidth(previewResizeStartWidthRef.current - translationX, wideLayoutWidth),
+      );
+    },
+    [wideLayoutWidth],
+  );
+
+  const previewResizeGesture = useMemo(
+    () =>
+      Gesture.Pan()
+        .runOnJS(true)
+        .onBegin(beginPreviewResize)
+        .onUpdate((event) => resizePreview(event.translationX)),
+    [beginPreviewResize, resizePreview],
+  );
+
   const showMessageCopiedToast = useCallback(() => {
     copyToastIdRef.current += 1;
     setCopyToast({ id: copyToastIdRef.current });
   }, []);
 
   const isPairing = isPastePairing || isHandlingScan;
+  const isWorkspacePreviewVisible = usesWideLayout ? showsWidePreviewPane : activePagerPage === 1;
+  const chatPane = (
+    <ChatShell
+      banner={
+        <Animated.View layout={chatBannerLayoutTransition} style={styles.bannerStack}>
+          <ConnectionBanner
+            connection={connection}
+            error={error}
+            hasPairedSession={hasPairedSession}
+            serverUrl={serverUrl}
+            workspacePath={workspacePath}
+            onRefresh={refresh}
+            onScanConnect={openScanner}
+          />
+        </Animated.View>
+      }
+      composerDisabled={connection === "offline"}
+      composerInputEditable={connection !== "offline" || hasPairedSession}
+      composerFocusRecoveryKey={connection}
+      collaborationMode={collaborationMode}
+      composerFocusRequestKey={composerFocusRequestKey}
+      composerFooter={
+        <ChatControls
+          models={models}
+          runtimeMode={runtimeMode}
+          selectedReasoningEffort={selectedReasoningEffort}
+          selectedServiceTier={selectedServiceTier}
+          selectedModel={selectedModel}
+          onRuntimeModeChange={changeRuntimeMode}
+          onSelectedReasoningEffortChange={changeSelectedReasoningEffort}
+          onSelectedServiceTierChange={changeSelectedServiceTier}
+          onSelectedModelChange={changeSelectedModel}
+        />
+      }
+      contextWindowUsage={contextWindowUsage}
+      goal={activeThread?.goal ?? null}
+      inputNativeID={CHAT_INPUT_NATIVE_ID}
+      isAttachingImage={isAttachingImages}
+      isLoadingMessages={isLoadingMessages}
+      isRunning={isRunning}
+      leadingAction={{
+        icon: usesExpandedSidebar ? (isSidebarVisible ? "sidebarHide" : "sidebarShow") : "menu",
+        label: usesExpandedSidebar
+          ? isSidebarVisible
+            ? "Hide threads"
+            : "Show threads"
+          : "Open threads",
+        onPress: usesExpandedSidebar ? toggleThreadSidebar : openThreadDrawer,
+      }}
+      messages={messages}
+      onAttachImage={attachImagesFromGallery}
+      onCancel={stopRun}
+      onCollaborationModeChange={changeCollaborationMode}
+      onAddPlanContext={addPlanContext}
+      onImplementPlan={implementPlan}
+      onIgnoreInputRequest={(request) => void ignoreInputRequest(request)}
+      onMessageCopied={showMessageCopiedToast}
+      onOpenMarkdownAttachment={openMarkdownAttachmentPreview}
+      onRefreshUsageStatus={() => refreshUsageStatus()}
+      onSubmitInputRequest={(request, answers) => void submitInputRequest(request, answers)}
+      onRemoveQueuedPrompt={(item) => void removeQueuedPrompt(item)}
+      onRestoreQueuedPrompt={(item) => void restoreQueuedPrompt(item)}
+      onSend={() => sendPrompt()}
+      onSteerQueuedPrompt={(item) => void steerQueuedPrompt(item)}
+      onClearGoal={clearThreadGoal}
+      onSaveGoal={saveThreadGoalObjective}
+      onToggleGoalPause={toggleThreadGoalPause}
+      pendingInputRequest={pendingInputRequest}
+      queuedPrompts={queuedPrompts}
+      rateLimitBuckets={rateLimitBuckets}
+      skills={skills}
+      skillsLoadState={skillsLoadState}
+      subtitle={activeWorkspacePath ?? "codex-relay"}
+      threadId={activeThreadId}
+      title={activeThread?.title ?? "Codex Relay"}
+      trailingActions={[
+        {
+          disabled: isRunning,
+          icon: "newThread",
+          label: "New thread",
+          onPress: createNewThread,
+        },
+        {
+          icon: usesWideLayout ? (isWidePreviewVisible ? "previewHide" : "preview") : "preview",
+          label: usesWideLayout
+            ? isWidePreviewVisible
+              ? "Hide workspace preview"
+              : "Show workspace preview"
+            : "Workspace preview",
+          onPress: usesWideLayout
+            ? toggleWorkspacePreview
+            : () =>
+                openWorkspacePreview({
+                  protocol: WORKSPACE_PREVIEW_OPEN_PROTOCOL,
+                  tab: "git",
+                  workspacePath: activeWorkspacePath,
+                }),
+        },
+      ]}
+      workspacePath={activeWorkspacePath}
+    />
+  );
+  const workspacePreviewPane = (
+    <WorkspacePreviewSurface
+      key={activeThreadId ?? "no-thread"}
+      isFocused={isWorkspacePreviewVisible}
+      isRunning={isRunning}
+      isLoadingChanges={isLoadingChanges}
+      serverUrl={serverUrl}
+      workspaceChanges={workspaceChanges}
+      workspaceChangesError={workspaceChangesError}
+      workspacePath={activeWorkspacePath}
+      markdownPreviewTarget={markdownPreviewTarget}
+      webPreviewTarget={activeWebPreviewTarget}
+      onClose={closeWorkspacePreview}
+      showCloseButton
+      onCheckoutBranch={checkoutBranch}
+      onCommitPush={commitPush}
+      onCreatePullRequest={createPullRequest}
+      onRefreshChanges={loadWorkspaceChanges}
+    />
+  );
 
   return (
     <>
-      <PagerView
-        ref={pagerRef}
-        initialPage={0}
-        onPageSelected={(event) => setActivePagerPage(event.nativeEvent.position)}
-        style={styles.pager}
-      >
-        <View key="chat" collapsable={false} style={styles.pagerPage}>
-          <ChatShell
-            banner={
-              <Animated.View layout={chatBannerLayoutTransition} style={styles.bannerStack}>
-                <ConnectionBanner
-                  connection={connection}
-                  error={error}
-                  hasPairedSession={hasPairedSession}
-                  serverUrl={serverUrl}
-                  workspacePath={workspacePath}
-                  onRefresh={refresh}
-                  onScanConnect={openScanner}
-                />
-              </Animated.View>
-            }
-            composerDisabled={connection === "offline"}
-            composerInputEditable={connection !== "offline" || hasPairedSession}
-            composerFocusRecoveryKey={connection}
-            collaborationMode={collaborationMode}
-            composerFocusRequestKey={composerFocusRequestKey}
-            composerFooter={
-              <ChatControls
-                models={models}
-                runtimeMode={runtimeMode}
-                selectedReasoningEffort={selectedReasoningEffort}
-                selectedServiceTier={selectedServiceTier}
-                selectedModel={selectedModel}
-                onRuntimeModeChange={changeRuntimeMode}
-                onSelectedReasoningEffortChange={changeSelectedReasoningEffort}
-                onSelectedServiceTierChange={changeSelectedServiceTier}
-                onSelectedModelChange={changeSelectedModel}
-              />
-            }
-            contextWindowUsage={contextWindowUsage}
-            goal={activeThread?.goal ?? null}
-            inputNativeID={CHAT_INPUT_NATIVE_ID}
-            isAttachingImage={isAttachingImages}
-            isLoadingMessages={isLoadingMessages}
-            isRunning={isRunning}
-            leadingAction={{
-              icon: "menu",
-              label: "Open threads",
-              onPress: openThreadDrawer,
-            }}
-            messages={messages}
-            onAttachImage={attachImagesFromGallery}
-            onCancel={stopRun}
-            onCollaborationModeChange={changeCollaborationMode}
-            onAddPlanContext={addPlanContext}
-            onImplementPlan={implementPlan}
-            onIgnoreInputRequest={(request) => void ignoreInputRequest(request)}
-            onMessageCopied={showMessageCopiedToast}
-            onOpenMarkdownAttachment={openMarkdownAttachmentPreview}
-            onRefreshUsageStatus={() => refreshUsageStatus()}
-            onSubmitInputRequest={(request, answers) => void submitInputRequest(request, answers)}
-            onRemoveQueuedPrompt={(item) => void removeQueuedPrompt(item)}
-            onRestoreQueuedPrompt={(item) => void restoreQueuedPrompt(item)}
-            onSend={() => sendPrompt()}
-            onSteerQueuedPrompt={(item) => void steerQueuedPrompt(item)}
-            onClearGoal={clearThreadGoal}
-            onSaveGoal={saveThreadGoalObjective}
-            onToggleGoalPause={toggleThreadGoalPause}
-            pendingInputRequest={pendingInputRequest}
-            queuedPrompts={queuedPrompts}
-            rateLimitBuckets={rateLimitBuckets}
-            skills={skills}
-            skillsLoadState={skillsLoadState}
-            subtitle={activeWorkspacePath ?? "codex-relay"}
-            threadId={activeThreadId}
-            title={activeThread?.title ?? "Codex Relay"}
-            trailingActions={[
-              {
-                disabled: isRunning,
-                icon: "newThread",
-                label: "New thread",
-                onPress: createNewThread,
-              },
-              {
-                icon: "preview",
-                label: "Workspace preview",
-                onPress: () =>
-                  openWorkspacePreview({
-                    protocol: WORKSPACE_PREVIEW_OPEN_PROTOCOL,
-                    tab: "git",
-                    workspacePath: activeWorkspacePath,
-                  }),
-              },
+      {usesWideLayout ? (
+        <View onLayout={onWideLayout} style={styles.wideLayout}>
+          <View
+            style={[
+              styles.wideChatPane,
+              wideLayoutWidth > 0 ? { width: wideChatPaneWidth } : styles.wideChatPaneInitial,
             ]}
-            workspacePath={activeWorkspacePath}
-          />
+          >
+            {chatPane}
+          </View>
+          {showsWidePreviewPane ? (
+            <>
+              <GestureDetector gesture={previewResizeGesture}>
+                <Animated.View
+                  accessibilityLabel="Resize workspace preview"
+                  style={styles.previewResizeHandle}
+                >
+                  <View style={styles.previewResizeGrip} />
+                </Animated.View>
+              </GestureDetector>
+              <View
+                style={[
+                  styles.widePreviewPane,
+                  wideLayoutWidth > 0
+                    ? { width: clampedPreviewPaneWidth }
+                    : styles.widePreviewPaneInitial,
+                ]}
+              >
+                {workspacePreviewPane}
+              </View>
+            </>
+          ) : null}
         </View>
-        <View key="changes" collapsable={false} style={styles.pagerPage}>
-          <WorkspacePreviewSurface
-            key={activeThreadId ?? "no-thread"}
-            isFocused={activePagerPage === 1}
-            isRunning={isRunning}
-            isLoadingChanges={isLoadingChanges}
-            serverUrl={serverUrl}
-            workspaceChanges={workspaceChanges}
-            workspaceChangesError={workspaceChangesError}
-            workspacePath={activeWorkspacePath}
-            markdownPreviewTarget={markdownPreviewTarget}
-            webPreviewTarget={activeWebPreviewTarget}
-            onClose={closeWorkspacePreview}
-            onCheckoutBranch={checkoutBranch}
-            onCommitPush={commitPush}
-            onCreatePullRequest={createPullRequest}
-            onRefreshChanges={loadWorkspaceChanges}
-          />
-        </View>
-      </PagerView>
+      ) : (
+        <PagerView
+          ref={pagerRef}
+          initialPage={activePagerPage}
+          onPageSelected={(event) => setActivePagerPage(event.nativeEvent.position)}
+          style={styles.pager}
+        >
+          <View key="chat" collapsable={false} style={styles.pagerPage}>
+            {chatPane}
+          </View>
+          <View key="changes" collapsable={false} style={styles.pagerPage}>
+            {workspacePreviewPane}
+          </View>
+        </PagerView>
+      )}
       {copyToast ? (
         <AppToast
           key={copyToast.id}
@@ -2546,6 +2698,18 @@ function isBarcodeScannerCancellation(error: unknown) {
   return error instanceof Error && error.message.toLowerCase().includes("cancel");
 }
 
+function clampPreviewPaneWidth(value: number, layoutWidth: number) {
+  if (layoutWidth <= 0) {
+    return value;
+  }
+
+  const availableWidth = Math.max(0, layoutWidth - PREVIEW_RESIZE_HANDLE_WIDTH);
+  const minPreviewWidth = Math.min(MIN_PREVIEW_PANE_WIDTH, availableWidth * 0.45);
+  const minChatWidth = Math.min(MIN_CHAT_PANE_WIDTH, availableWidth * 0.55);
+  const maxPreviewWidth = Math.max(minPreviewWidth, availableWidth - minChatWidth);
+  return Math.min(maxPreviewWidth, Math.max(minPreviewWidth, value));
+}
+
 const chatBannerLayoutTransition = LinearTransition.duration(180);
 
 const styles = StyleSheet.create({
@@ -2557,6 +2721,38 @@ const styles = StyleSheet.create({
   },
   pagerPage: {
     flex: 1,
+  },
+  wideLayout: {
+    backgroundColor: Colors.dark.background,
+    flex: 1,
+    flexDirection: "row",
+  },
+  wideChatPane: {
+    minWidth: 0,
+  },
+  wideChatPaneInitial: {
+    flex: 1,
+  },
+  widePreviewPane: {
+    minWidth: 0,
+  },
+  widePreviewPaneInitial: {
+    flex: 1.08,
+  },
+  previewResizeGrip: {
+    backgroundColor: "rgba(255, 255, 255, 0.22)",
+    borderRadius: 1,
+    height: 44,
+    marginLeft: -1,
+    opacity: 0.72,
+    width: 2,
+  },
+  previewResizeHandle: {
+    alignItems: "flex-start",
+    borderLeftColor: "rgba(255, 255, 255, 0.08)",
+    borderLeftWidth: StyleSheet.hairlineWidth,
+    justifyContent: "center",
+    width: PREVIEW_RESIZE_HANDLE_WIDTH,
   },
   bannerStack: {
     flexShrink: 0,

--- a/apps/mobile/src/components/chat/ThreadDrawerContent.tsx
+++ b/apps/mobile/src/components/chat/ThreadDrawerContent.tsx
@@ -17,6 +17,7 @@ import {
   View,
   type ViewStyle,
 } from "react-native";
+import { Gesture, GestureDetector } from "react-native-gesture-handler";
 import Animated, {
   Easing,
   useAnimatedStyle,
@@ -106,7 +107,12 @@ type ThreadDrawerUiAction =
 
 type ThreadDrawerContentProps = Parameters<
   NonNullable<ComponentProps<typeof Drawer>["drawerContent"]>
->[0];
+>[0] & {
+  isPermanent?: boolean;
+  onSidebarResize?: (translationX: number) => void;
+  onSidebarResizeStart?: () => void;
+  showResizeHandle?: boolean;
+};
 
 type ThreadDrawerNavigation = ThreadDrawerContentProps["navigation"];
 
@@ -157,6 +163,7 @@ function threadDrawerUiReducer(
 
 export function ThreadDrawerContent(props: ThreadDrawerContentProps) {
   const drawerStatus = getDrawerStatus(props.state);
+  const isDrawerVisible = props.isPermanent || drawerStatus === "open";
   const insets = useSafeAreaInsets();
   const queryClient = useQueryClient();
   const createThreadMutation = useMutation({
@@ -208,7 +215,7 @@ export function ThreadDrawerContent(props: ThreadDrawerContentProps) {
   const versionQuery = useQuery({
     queryKey: serverStateKeys.version(),
     queryFn: serverStateQueryFns.version,
-    enabled: drawerStatus === "open",
+    enabled: isDrawerVisible,
     retry: false,
     staleTime: 60_000,
   });
@@ -263,24 +270,37 @@ export function ThreadDrawerContent(props: ThreadDrawerContentProps) {
     opacity: searchProgress.value,
     transform: [{ translateY: (1 - searchProgress.value) * -4 }],
   }));
+  const sidebarResizeGesture = useMemo(
+    () =>
+      Gesture.Pan()
+        .runOnJS(true)
+        .onBegin(() => {
+          props.onSidebarResizeStart?.();
+          hapticSelection();
+        })
+        .onUpdate((event) => {
+          props.onSidebarResize?.(event.translationX);
+        }),
+    [props],
+  );
 
   useEffect(() => {
     const idleTask = requestIdleTask(
       () =>
         dispatchUi({
           type: "set-can-render-thread-list",
-          value: drawerStatus === "open",
+          value: isDrawerVisible,
         }),
       drawerListIdleTimeoutMs,
     );
     return () => cancelIdleTask(idleTask);
-  }, [drawerStatus]);
+  }, [isDrawerVisible]);
 
   useEffect(() => {
-    if (drawerStatus === "open") {
+    if (isDrawerVisible) {
       Keyboard.dismiss();
     }
-  }, [drawerStatus]);
+  }, [isDrawerVisible]);
 
   useEffect(() => {
     searchProgress.value = withTiming(normalizedSearchQuery ? 1 : 0, {
@@ -346,6 +366,7 @@ export function ThreadDrawerContent(props: ThreadDrawerContentProps) {
         hapticSelection();
         props.navigation.closeDrawer();
       }}
+      showCloseButton={!props.isPermanent}
       onNewChat={() => void openNewThreadWorkspacePicker()}
       onRefreshProjects={() => void refreshProjects()}
       onSearchChange={(value) => dispatchUi({ type: "set-search-query", value })}
@@ -404,6 +425,16 @@ export function ThreadDrawerContent(props: ThreadDrawerContentProps) {
         workspaceBrowser={workspaceBrowser}
         workspaceRows={workspaceRows}
       />
+      {props.showResizeHandle ? (
+        <GestureDetector gesture={sidebarResizeGesture}>
+          <Animated.View
+            accessibilityLabel="Resize threads sidebar"
+            style={styles.sidebarResizeHandle}
+          >
+            <View style={styles.sidebarResizeGrip} />
+          </Animated.View>
+        </GestureDetector>
+      ) : null}
     </View>
   );
 }
@@ -878,6 +909,7 @@ function DrawerListHeader({
   onSearchClear,
   searchClearAnimatedStyle,
   searchQuery,
+  showCloseButton,
   versionCompatibility,
 }: {
   isRefreshingProjects: boolean;
@@ -888,6 +920,7 @@ function DrawerListHeader({
   onSearchClear: () => void;
   searchClearAnimatedStyle: ReturnType<typeof useAnimatedStyle<ViewStyle>>;
   searchQuery: string;
+  showCloseButton: boolean;
   versionCompatibility: RelayVersionCompatibility | undefined;
 }) {
   const theme = useTheme();
@@ -896,15 +929,17 @@ function DrawerListHeader({
     <View style={styles.header}>
       <View style={styles.brandRow}>
         <Text style={styles.brandText}>Codex Relay</Text>
-        <Button
-          accessibilityLabel="Close menu"
-          onPress={onCloseMenu}
-          size="icon"
-          variant="ghost"
-          className="ml-auto size-8 rounded-md active:bg-accent/70"
-        >
-          <Icon name="closeMenu" size={17} tintColor={theme.textSecondary} />
-        </Button>
+        {showCloseButton ? (
+          <Button
+            accessibilityLabel="Close menu"
+            onPress={onCloseMenu}
+            size="icon"
+            variant="ghost"
+            className="ml-auto size-8 rounded-md active:bg-accent/70"
+          >
+            <Icon name="closeMenu" size={17} tintColor={theme.textSecondary} />
+          </Button>
+        ) : null}
       </View>
       <View style={styles.searchShell}>
         <Icon name="search" size={14} tintColor={theme.textSecondary} />
@@ -1417,6 +1452,7 @@ function formatRelativeTime(value: string) {
 const styles = StyleSheet.create({
   drawerRoot: {
     flex: 1,
+    position: "relative",
   },
   listContent: {
     flexGrow: 1,
@@ -1448,6 +1484,7 @@ const styles = StyleSheet.create({
     borderWidth: StyleSheet.hairlineWidth,
     flexDirection: "row",
     height: 32,
+    marginHorizontal: 4,
     paddingHorizontal: 9,
   },
   searchInput: {
@@ -1543,7 +1580,7 @@ const styles = StyleSheet.create({
     borderRadius: 7,
     flexDirection: "row",
     minHeight: 36,
-    paddingHorizontal: 0,
+    paddingHorizontal: 8,
   },
   newChatIcon: {
     alignItems: "center",
@@ -1561,12 +1598,14 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     gap: 2,
     marginLeft: "auto",
+    marginRight: 10,
   },
   sectionHeader: {
     alignItems: "center",
     flexDirection: "row",
     marginTop: 8,
     minHeight: 28,
+    paddingLeft: 8,
   },
   sectionTitle: {
     fontSize: 11,
@@ -1635,6 +1674,23 @@ const styles = StyleSheet.create({
   },
   drawerPressedContent: {
     opacity: 0.68,
+  },
+  sidebarResizeGrip: {
+    backgroundColor: "rgba(255, 255, 255, 0.2)",
+    borderRadius: 1,
+    height: 44,
+    opacity: 0.72,
+    width: 2,
+  },
+  sidebarResizeHandle: {
+    alignItems: "center",
+    bottom: 0,
+    justifyContent: "center",
+    position: "absolute",
+    right: -8,
+    top: 0,
+    width: 16,
+    zIndex: 40,
   },
   emptySearchState: {
     alignItems: "center",

--- a/apps/mobile/src/components/chat/WorkspacePreviewSurface.tsx
+++ b/apps/mobile/src/components/chat/WorkspacePreviewSurface.tsx
@@ -82,6 +82,7 @@ export function WorkspacePreviewSurface({
   markdownPreviewTarget,
   webPreviewTarget,
   onClose,
+  showCloseButton = true,
   onCheckoutBranch,
   onCommitPush,
   onCreatePullRequest,
@@ -97,6 +98,7 @@ export function WorkspacePreviewSurface({
   markdownPreviewTarget?: WorkspaceMarkdownPreviewTarget;
   webPreviewTarget?: WebPreviewTarget;
   onClose: () => void;
+  showCloseButton?: boolean;
   onCheckoutBranch: (branch: string) => Promise<void> | void;
   onCommitPush: () => Promise<void> | void;
   onCreatePullRequest: () => Promise<void> | void;
@@ -209,14 +211,16 @@ export function WorkspacePreviewSurface({
   return (
     <SafeAreaView edges={["top", "left", "right", "bottom"]} style={styles.screen}>
       <View style={styles.header}>
-        <Pressable
-          accessibilityRole="button"
-          accessibilityLabel="Back from workspace preview"
-          onPress={onClose}
-          style={({ pressed }) => [styles.iconButton, pressed && styles.pressed]}
-        >
-          <Icon name="back" size={18} tintColor={Colors.dark.text} />
-        </Pressable>
+        {showCloseButton ? (
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Back from workspace preview"
+            onPress={onClose}
+            style={({ pressed }) => [styles.iconButton, pressed && styles.pressed]}
+          >
+            <Icon name="back" size={18} tintColor={Colors.dark.text} />
+          </Pressable>
+        ) : null}
         <View style={styles.titleGroup}>
           <ThemedText type="smallBold" style={styles.title} numberOfLines={1}>
             Preview

--- a/apps/mobile/src/components/chat/ipad-split-layout.tsx
+++ b/apps/mobile/src/components/chat/ipad-split-layout.tsx
@@ -1,0 +1,102 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import { useWindowDimensions } from "react-native";
+
+export const EXPANDED_DRAWER_BREAKPOINT = 1100;
+export const THREE_PANE_LAYOUT_BREAKPOINT = 1280;
+
+const DEFAULT_SIDEBAR_WIDTH = 336;
+const MIN_SIDEBAR_WIDTH = 260;
+const MAX_SIDEBAR_WIDTH = 460;
+const MIN_MAIN_CONTENT_WIDTH = 760;
+
+type IpadSplitLayoutContextValue = {
+  beginSidebarResize: () => void;
+  isSidebarVisible: boolean;
+  resizeSidebar: (translationX: number) => void;
+  setSidebarVisible: (visible: boolean) => void;
+  sidebarWidth: number;
+  toggleSidebar: () => void;
+};
+
+const IpadSplitLayoutContext = createContext<IpadSplitLayoutContextValue | undefined>(undefined);
+
+export function IpadSplitLayoutProvider({ children }: { children: ReactNode }) {
+  const { width } = useWindowDimensions();
+  const [isSidebarVisible, setSidebarVisible] = useState(true);
+  const [sidebarWidth, setSidebarWidth] = useState(DEFAULT_SIDEBAR_WIDTH);
+  const sidebarResizeStartWidthRef = useRef(DEFAULT_SIDEBAR_WIDTH);
+
+  const clampSidebarWidthForScreen = useCallback(
+    (value: number) => clampSidebarWidth(value, width),
+    [width],
+  );
+
+  useEffect(() => {
+    setSidebarWidth((current) => clampSidebarWidthForScreen(current));
+  }, [clampSidebarWidthForScreen]);
+
+  const beginSidebarResize = useCallback(() => {
+    sidebarResizeStartWidthRef.current = sidebarWidth;
+  }, [sidebarWidth]);
+
+  const resizeSidebar = useCallback(
+    (translationX: number) => {
+      setSidebarWidth(
+        clampSidebarWidthForScreen(sidebarResizeStartWidthRef.current + translationX),
+      );
+    },
+    [clampSidebarWidthForScreen],
+  );
+
+  const toggleSidebar = useCallback(() => {
+    setSidebarVisible((current) => !current);
+  }, []);
+
+  const value = useMemo(
+    () => ({
+      beginSidebarResize,
+      isSidebarVisible,
+      resizeSidebar,
+      setSidebarVisible,
+      sidebarWidth,
+      toggleSidebar,
+    }),
+    [
+      beginSidebarResize,
+      isSidebarVisible,
+      resizeSidebar,
+      setSidebarVisible,
+      sidebarWidth,
+      toggleSidebar,
+    ],
+  );
+
+  return (
+    <IpadSplitLayoutContext.Provider value={value}>{children}</IpadSplitLayoutContext.Provider>
+  );
+}
+
+export function useIpadSplitLayout() {
+  const value = useContext(IpadSplitLayoutContext);
+  if (!value) {
+    throw new Error("useIpadSplitLayout must be used within IpadSplitLayoutProvider.");
+  }
+  return value;
+}
+
+function clampSidebarWidth(value: number, screenWidth: number) {
+  const screenLimitedMax = Math.max(
+    MIN_SIDEBAR_WIDTH,
+    Math.min(MAX_SIDEBAR_WIDTH, screenWidth - MIN_MAIN_CONTENT_WIDTH),
+  );
+  return Math.min(screenLimitedMax, Math.max(MIN_SIDEBAR_WIDTH, value));
+}

--- a/apps/mobile/src/components/ui/icon.tsx
+++ b/apps/mobile/src/components/ui/icon.tsx
@@ -24,7 +24,10 @@ import {
   LogOut,
   Menu,
   Mic,
+  PanelRightClose,
   PanelRightOpen,
+  PanelLeftClose,
+  PanelLeftOpen,
   Plus,
   RefreshCw,
   Search,
@@ -69,12 +72,15 @@ export type AppIconName =
   | "permissionsDefault"
   | "permissionsFull"
   | "preview"
+  | "previewHide"
   | "pullRequest"
   | "refresh"
   | "running"
   | "search"
   | "send"
   | "sendToLine"
+  | "sidebarHide"
+  | "sidebarShow"
   | "back"
   | "forward"
   | "settings"
@@ -117,12 +123,15 @@ const iconComponents: Record<AppIconName, LucideComponent> = {
   permissionsDefault: Hand,
   permissionsFull: ShieldCheck,
   preview: PanelRightOpen,
+  previewHide: PanelRightClose,
   pullRequest: GitPullRequest,
   refresh: RefreshCw,
   running: LoaderCircle,
   search: Search,
   send: ArrowUp,
   sendToLine: ArrowRightToLine,
+  sidebarHide: PanelLeftClose,
+  sidebarShow: PanelLeftOpen,
   back: ArrowLeft,
   forward: ArrowRight,
   settings: Settings,

--- a/apps/mobile/src/types/css.d.ts
+++ b/apps/mobile/src/types/css.d.ts
@@ -1,3 +1,5 @@
+declare module "*.css";
+
 declare module "*.module.css" {
   const classes: Record<string, string>;
   export default classes;


### PR DESCRIPTION
## Summary
- enable iPad support and iPad-specific orientations in the Expo config
- add a responsive iPad split layout with a resizable thread sidebar and workspace preview pane
- support a collapsed left rail and collapsible workspace preview while preserving the existing compact drawer/pager behavior

Closes #6.

## Validation
- pnpm --filter @codex-relay/mobile typecheck
- pnpm --filter @codex-relay/mobile lint
- pnpm --filter @codex-relay/mobile format:check
- iPad Release build installed and launched successfully for manual testing