### PR TITLE
Fix skill discovery

### DIFF
--- a/packages/codex-relay/src/skill-discovery.ts
+++ b/packages/codex-relay/src/skill-discovery.ts
@@ -1,5 +1,5 @@
 import type { Dirent } from "node:fs";
-import { readdir, readFile } from "node:fs/promises";
+import { readdir, readFile, realpath, stat } from "node:fs/promises";
 import { homedir } from "node:os";
 import { basename, dirname, join } from "node:path";
 
@@ -67,11 +67,23 @@ export async function listAvailableSkills(
 
 async function findSkillFiles(root: SkillSearchRoot) {
   const found: Array<SkillSearchRoot & { path: string }> = [];
+  const visitedDirectories = new Set<string>();
 
   async function walk(path: string, depth: number) {
     if (depth < 0) {
       return;
     }
+
+    let realDirectoryPath: string;
+    try {
+      realDirectoryPath = await realpath(path);
+    } catch {
+      return;
+    }
+    if (visitedDirectories.has(realDirectoryPath)) {
+      return;
+    }
+    visitedDirectories.add(realDirectoryPath);
 
     let entries: Dirent[];
     try {
@@ -82,11 +94,12 @@ async function findSkillFiles(root: SkillSearchRoot) {
 
     for (const entry of entries) {
       const entryPath = join(path, entry.name);
-      if (entry.isFile() && entry.name === "SKILL.md") {
+      const kind = await directoryEntryKind(entry, entryPath);
+      if (kind === "file" && entry.name === "SKILL.md") {
         found.push({ ...root, path: entryPath });
         continue;
       }
-      if (!entry.isDirectory() || entry.name === "node_modules") {
+      if (kind !== "directory" || entry.name === "node_modules") {
         continue;
       }
       await walk(entryPath, depth - 1);
@@ -95,6 +108,31 @@ async function findSkillFiles(root: SkillSearchRoot) {
 
   await walk(root.path, root.maxDepth);
   return found;
+}
+
+async function directoryEntryKind(entry: Dirent, entryPath: string) {
+  if (entry.isFile()) {
+    return "file";
+  }
+  if (entry.isDirectory()) {
+    return "directory";
+  }
+  if (!entry.isSymbolicLink()) {
+    return null;
+  }
+
+  try {
+    const target = await stat(entryPath);
+    if (target.isFile()) {
+      return "file";
+    }
+    if (target.isDirectory()) {
+      return "directory";
+    }
+  } catch {
+    return null;
+  }
+  return null;
 }
 
 async function readSkill(entry: SkillSearchRoot & { path: string }): Promise<AgentSkill | null> {

--- a/packages/codex-relay/src/skill-discovery.ts
+++ b/packages/codex-relay/src/skill-discovery.ts
@@ -219,7 +219,10 @@ function formatBlockScalar(marker: string, lines: string[]) {
   if (marker.startsWith("|")) {
     return trimmedLines.join("\n").trim();
   }
-  return trimmedLines.map((line) => line.trim()).filter(Boolean).join(" ");
+  return trimmedLines
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .join(" ");
 }
 
 function markdownBody(markdown: string) {

--- a/packages/codex-relay/src/skill-discovery.ts
+++ b/packages/codex-relay/src/skill-discovery.ts
@@ -165,7 +165,7 @@ async function readSkill(entry: SkillSearchRoot & { path: string }): Promise<Age
 
 function parseSkillMarkdown(markdown: string): ParsedSkill {
   const frontmatter = parseFrontmatter(markdown);
-  const heading = markdown.match(/^#\s+(.+)$/m)?.[1]?.trim();
+  const heading = firstMarkdownHeading(markdownBody(markdown));
   return {
     description: frontmatter.description,
     displayName: heading ? cleanHeading(heading) : undefined,
@@ -184,14 +184,72 @@ function parseFrontmatter(markdown: string) {
   }
 
   const fields: Record<string, string> = {};
-  for (const line of markdown.slice(4, end).split("\n")) {
+  const lines = markdown.slice(4, end).split("\n");
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index];
     const match = line.match(/^([A-Za-z0-9_-]+):\s*(.*)$/);
     if (!match) {
       continue;
     }
-    fields[match[1]] = unquoteYamlScalar(match[2].trim());
+    const key = match[1];
+    const value = match[2].trim();
+    if (isBlockScalar(value)) {
+      const blockLines: string[] = [];
+      while (
+        index + 1 < lines.length &&
+        (lines[index + 1].trim() === "" || /^\s/.test(lines[index + 1]))
+      ) {
+        index += 1;
+        blockLines.push(lines[index].replace(/^\s+/, ""));
+      }
+      fields[key] = formatBlockScalar(value, blockLines);
+      continue;
+    }
+    fields[key] = unquoteYamlScalar(value);
   }
   return fields;
+}
+
+function isBlockScalar(value: string) {
+  return ["|", "|-", "|+", ">", ">-", ">+"].includes(value);
+}
+
+function formatBlockScalar(marker: string, lines: string[]) {
+  const trimmedLines = lines.map((line) => line.trimEnd());
+  if (marker.startsWith("|")) {
+    return trimmedLines.join("\n").trim();
+  }
+  return trimmedLines.map((line) => line.trim()).filter(Boolean).join(" ");
+}
+
+function markdownBody(markdown: string) {
+  if (!markdown.startsWith("---\n")) {
+    return markdown;
+  }
+  const end = markdown.indexOf("\n---", 4);
+  if (end < 0) {
+    return markdown;
+  }
+  return markdown.slice(end + 4).replace(/^\r?\n/, "");
+}
+
+function firstMarkdownHeading(markdown: string) {
+  let fence: string | undefined;
+  for (const line of markdown.split("\n")) {
+    const fenceMatch = line.match(/^\s*(```|~~~)/);
+    if (fenceMatch) {
+      fence = fence ? undefined : fenceMatch[1];
+      continue;
+    }
+    if (fence) {
+      continue;
+    }
+    const heading = line.match(/^#\s+(.+)$/)?.[1]?.trim();
+    if (heading) {
+      return heading;
+    }
+  }
+  return undefined;
 }
 
 function unquoteYamlScalar(value: string) {

--- a/packages/codex-relay/test/app.test.ts
+++ b/packages/codex-relay/test/app.test.ts
@@ -631,6 +631,46 @@ describe("Codex Relay server routes", () => {
     );
   });
 
+  it("parses folded descriptions and ignores headings inside code fences", async () => {
+    const workspacePath = await mkdtemp(join(tmpdir(), "codex-relay-workspace-"));
+    const skillPath = join(workspacePath, ".agents", "skills", "marimo-pair");
+    await mkdir(skillPath, { recursive: true });
+    await writeFile(
+      join(skillPath, "SKILL.md"),
+      [
+        "---",
+        "name: marimo-pair",
+        "description: >-",
+        "  Drive a live marimo notebook as a workspace.",
+        "  Inspect live notebook state.",
+        "---",
+        "",
+        "Introductory text without a top-level heading.",
+        "",
+        "```python",
+        "# Public definitions: values, total, i, value, mean",
+        "values = [1, 2, 3]",
+        "```",
+        "",
+      ].join("\n"),
+    );
+    const app = createApp({ codex: createMockCodex(), workspacePath });
+
+    const response = await app.request("/v1/skills");
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.skills).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: "marimo-pair",
+          displayName: "Marimo Pair",
+          description: "Drive a live marimo notebook as a workspace. Inspect live notebook state.",
+        }),
+      ]),
+    );
+  });
+
   it("lists directories outside the configured workspace when a cwd points there", async () => {
     const workspacePath = await mkdtemp(join(tmpdir(), "codex-relay-workspace-"));
     const externalPath = await mkdtemp(join(tmpdir(), "codex-relay-external-"));

--- a/packages/codex-relay/test/app.test.ts
+++ b/packages/codex-relay/test/app.test.ts
@@ -5,7 +5,7 @@ import { hkdf } from "@noble/hashes/hkdf.js";
 import { sha256 } from "@noble/hashes/sha2.js";
 import { fromByteArray, toByteArray } from "base64-js";
 import { execFile } from "node:child_process";
-import { mkdtemp, mkdir, readFile, writeFile } from "node:fs/promises";
+import { mkdtemp, mkdir, readFile, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { basename, dirname, join } from "node:path";
 import { promisify } from "node:util";
@@ -583,6 +583,47 @@ describe("Codex Relay server routes", () => {
           name: "agent-device",
           displayName: "Agent Device",
           description: "Automates interactions for mobile devices.",
+          source: "workspace",
+          sourceLabel: basename(workspacePath),
+        }),
+      ]),
+    );
+  });
+
+  it("lists workspace skills from symlinked skill directories", async () => {
+    const workspacePath = await mkdtemp(join(tmpdir(), "codex-relay-workspace-"));
+    const vendorPath = await mkdtemp(join(tmpdir(), "codex-relay-vendor-skills-"));
+    const vendorSkillPath = join(vendorPath, "marimo-notebook");
+    const workspaceSkillsPath = join(workspacePath, ".agents", "skills");
+    const workspaceSkillLink = join(workspaceSkillsPath, "marimo-notebook");
+    await mkdir(vendorSkillPath, { recursive: true });
+    await mkdir(workspaceSkillsPath, { recursive: true });
+    await writeFile(
+      join(vendorSkillPath, "SKILL.md"),
+      [
+        "---",
+        "name: marimo-notebook",
+        "description: Write marimo notebooks.",
+        "---",
+        "",
+        "# Marimo Notebook",
+        "",
+      ].join("\n"),
+    );
+    await symlink(vendorSkillPath, workspaceSkillLink, "dir");
+    const app = createApp({ codex: createMockCodex(), workspacePath });
+
+    const response = await app.request("/v1/skills");
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.skills).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: "marimo-notebook",
+          displayName: "Marimo Notebook",
+          description: "Write marimo notebooks.",
+          path: join(workspaceSkillLink, "SKILL.md"),
           source: "workspace",
           sourceLabel: basename(workspacePath),
         }),


### PR DESCRIPTION
## Summary

First of all, thanks for putting together this app, it's great!

- I noticed that some skills that I have which are symlinked were not being discovered. So now follow symlinked skill directories during skill discovery too.
- Also I noticed that for some SKILL.md files that had multiline YAML descriptions (e.g "description: >-") they were not being read correctly, so now the parser handles those folded descriptions. 
- Similarly now ignore markdown headings inside fenced codeblocks when deriving the skill's display name. 

## Validation

- `pnpm --filter codex-relay test`
- `pnpm typecheck`
- `pnpm lint`

## Notes

Skill not displaying
<img width="645" height="312" alt="image" src="https://github.com/user-attachments/assets/d4cae0d3-0bbe-4243-97a6-19acc0049e58" />

Description read bug
<img width="645" height="370" alt="image" src="https://github.com/user-attachments/assets/c318426e-9826-4be8-9c4d-a0782cd35fb9" />

Fixed
<img width="645" height="377" alt="image" src="https://github.com/user-attachments/assets/ef688bb6-a685-4e3f-8454-54cf1f1abe9b" />
