### PR TITLE
feat: add shared terminal and mobile sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,22 @@ npx codex-relay@latest approve XXXX-XXXX
 
 Your phone can now talk to your local Codex session.
 
+### 3. Optional: share a live session with your terminal
+
+The default relay uses its own Codex app-server process. To make mobile and a terminal TUI use the same socket-backed app-server on macOS, Linux, or WSL, start the relay with:
+
+```sh
+npx codex-relay@latest --shared-app-server
+```
+
+Then attach a new terminal TUI:
+
+```sh
+codex resume --remote unix://
+```
+
+An already-running standalone TUI cannot be converted in place. Exit it and reconnect with `--remote`. Shared mode requires a recent Codex CLI with Unix-socket app-server and remote-resume support; native Windows should use WSL or the default private mode.
+
 ## Network Setup
 
 Your phone must be able to open the `Mobile:` URL printed by Codex Relay.
@@ -135,26 +151,28 @@ URL printed by the computer.
 
 ## Common Commands
 
-| Command                                    | What it does                                        |
-| ------------------------------------------ | --------------------------------------------------- |
-| `npx codex-relay@latest`                   | Start the relay and print a pairing QR.             |
-| `npx codex-relay@latest --bg`              | Keep the relay running in the background.           |
-| `npx codex-relay@latest qr`                | Print the current pairing QR for an existing relay. |
-| `npx codex-relay@latest approve XXXX-XXXX` | Approve a pending mobile pairing request.           |
-| `npx codex-relay@latest clear`             | Sign out every paired mobile app.                   |
+| Command                                      | What it does                                        |
+| -------------------------------------------- | --------------------------------------------------- |
+| `npx codex-relay@latest`                     | Start the relay and print a pairing QR.             |
+| `npx codex-relay@latest --bg`                | Keep the relay running in the background.           |
+| `npx codex-relay@latest --shared-app-server` | Share live sessions with an attached terminal TUI.  |
+| `npx codex-relay@latest qr`                  | Print the current pairing QR for an existing relay. |
+| `npx codex-relay@latest approve XXXX-XXXX`   | Approve a pending mobile pairing request.           |
+| `npx codex-relay@latest clear`               | Sign out every paired mobile app.                   |
 
 ## Configuration
 
 The relay listens on `0.0.0.0:8787` by default.
 
-| Variable                     | Purpose                                                             |
-| ---------------------------- | ------------------------------------------------------------------- |
-| `PORT`                       | Server port. Defaults to `8787`.                                    |
-| `HOST`                       | Listen host. Defaults to `0.0.0.0`.                                 |
-| `CODEX_RELAY_WORKSPACE_PATH` | Workspace path Codex should use. Defaults to the current directory. |
-| `CODEX_RELAY_AUTH_DB_PATH`   | Pairing and session database path.                                  |
-| `CODEX_BIN`                  | Codex CLI executable path.                                          |
-| `CODEX_HOME`                 | Codex home directory for reading local session metadata.            |
+| Variable                      | Purpose                                                             |
+| ----------------------------- | ------------------------------------------------------------------- |
+| `PORT`                        | Server port. Defaults to `8787`.                                    |
+| `HOST`                        | Listen host. Defaults to `0.0.0.0`.                                 |
+| `CODEX_RELAY_WORKSPACE_PATH`  | Workspace path Codex should use. Defaults to the current directory. |
+| `CODEX_RELAY_AUTH_DB_PATH`    | Pairing and session database path.                                  |
+| `CODEX_RELAY_APP_SERVER_MODE` | `socket` for shared terminal/mobile sessions; defaults to `stdio`.  |
+| `CODEX_BIN`                   | Codex CLI executable path.                                          |
+| `CODEX_HOME`                  | Codex home directory for reading local session metadata.            |
 
 Background mode writes runtime files under `.codex-relay/` in the current
 workspace, including server logs, process state, and pairing data.

--- a/packages/codex-relay/README.md
+++ b/packages/codex-relay/README.md
@@ -28,6 +28,26 @@ npx codex-relay@latest approve XXXX-XXXX
 
 After approval, the phone can list Codex threads, start new work, stream messages, and handle approval prompts from the local Codex runtime.
 
+## Shared Terminal and Mobile Sessions
+
+By default, Codex Relay starts a private app-server process. A terminal TUI that was started separately can resume the same saved thread, but it does not receive the relay process's live events.
+
+On macOS, Linux, or WSL, opt in to Codex's shared app-server socket:
+
+```sh
+npx codex-relay@latest --shared-app-server
+```
+
+Then connect a new terminal TUI to the shared app-server socket:
+
+```sh
+codex resume --remote unix://
+```
+
+Pass a thread ID after `unix://` to open a specific thread. The relay prints the attach command at startup. Mobile and the connected terminal can then observe the same live sessions through one socket-backed app-server. An already-running standalone TUI cannot be converted in place; exit it and reconnect with `--remote`.
+
+Shared mode requires a recent Codex CLI with Unix-socket app-server and `resume --remote` support. If those features are unavailable, update Codex or omit `--shared-app-server` to keep the existing private mode. Native Windows is not currently supported; use WSL or private mode there.
+
 ## Background Mode
 
 To keep the relay running after the command returns:
@@ -70,6 +90,12 @@ npx codex-relay@latest --bg
 Start the relay in the background.
 
 ```sh
+npx codex-relay@latest --shared-app-server
+```
+
+Start the relay through Codex's shared app-server socket.
+
+```sh
 npx codex-relay@latest qr
 ```
 
@@ -99,6 +125,7 @@ The relay listens on `0.0.0.0:8787` by default. Configure it with environment va
 | `CODEX_RELAY_AUTH_DB_PATH`             | Pairing and session database path. Defaults to `.codex-relay/auth.db`.                             |
 | `CODEX_RELAY_APPROVAL_SECRET`          | Secret used by the local approve command. Usually generated automatically.                         |
 | `CODEX_RELAY_DANGEROUSLY_AUTO_APPROVE` | Set to `1` to auto-approve mobile pairing requests. Prefer the CLI flag for local use.             |
+| `CODEX_RELAY_APP_SERVER_MODE`          | Set to `socket` for shared terminal/mobile sessions. Defaults to `stdio`.                          |
 | `CODEX_HOME`                           | Codex home directory, used when reading Codex session metadata.                                    |
 | `CODEX_BIN`                            | Codex CLI executable path.                                                                         |
 

--- a/packages/codex-relay/src/app-server.ts
+++ b/packages/codex-relay/src/app-server.ts
@@ -1,7 +1,16 @@
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { access } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
 import { createInterface, type Interface } from "node:readline";
+import { setTimeout } from "node:timers/promises";
+import WebSocket from "ws";
 
-import { resolveCodexAppServerSpawn } from "./codex-binary.js";
+import {
+  resolveCodexAppServerMode,
+  resolveCodexAppServerSpawn,
+  resolveCodexSharedAppServerSpawn,
+} from "./codex-binary.js";
 
 type JsonRpcServerMessage = {
   id?: number;
@@ -242,6 +251,12 @@ export class CodexAppServerClient {
   private pending = new Map<number, PendingRequest>();
   private requestHandlers = new Set<(request: AppServerRequest) => void>();
   private readline: Interface | undefined;
+  private sharedServer: ChildProcessWithoutNullStreams | undefined;
+  private socket: WebSocket | undefined;
+
+  initialize() {
+    return this.ensureInitialized();
+  }
 
   async listThreads(limit = 80) {
     const response = await this.request<{ data: AppServerThread[] }>("thread/list", {
@@ -339,8 +354,12 @@ export class CodexAppServerClient {
     this.pending.clear();
     this.readline?.close();
     this.child?.kill();
+    this.socket?.close();
+    this.sharedServer?.kill();
     this.readline = undefined;
     this.child = undefined;
+    this.socket = undefined;
+    this.sharedServer = undefined;
     this.initialized = undefined;
   }
 
@@ -350,9 +369,8 @@ export class CodexAppServerClient {
     debugAppServer("request", method, id);
     return new Promise<T>((resolve, reject) => {
       this.pending.set(id, { method, resolve: (value) => resolve(value as T), reject });
-      this.child!.stdin.write(`${JSON.stringify({ id, method, params })}\n`, (error) => {
-        if (error) {
-          this.pending.delete(id);
+      void this.writeJson({ id, method, params }).catch((error: Error) => {
+        if (this.pending.delete(id)) {
           reject(error);
         }
       });
@@ -366,7 +384,38 @@ export class CodexAppServerClient {
     return this.initialized;
   }
 
-  private start() {
+  private async start() {
+    try {
+      if (resolveCodexAppServerMode() === "socket") {
+        this.sharedServer = await startSharedCodexAppServer();
+        await this.connectSharedCodexAppServer();
+      } else {
+        this.startStdioCodexAppServer();
+      }
+      await this.requestRaw("initialize", {
+        clientInfo: {
+          name: "codex-relay",
+          title: "Codex Relay Mobile Server",
+          version: "1.2.0",
+        },
+        capabilities: {
+          experimentalApi: true,
+        },
+      });
+    } catch (error) {
+      this.readline?.close();
+      this.readline = undefined;
+      this.child?.kill();
+      this.child = undefined;
+      this.socket?.close();
+      this.socket = undefined;
+      this.sharedServer?.kill();
+      this.sharedServer = undefined;
+      throw error;
+    }
+  }
+
+  private startStdioCodexAppServer() {
     const spawnConfig = resolveCodexAppServerSpawn();
     this.child = spawn(spawnConfig.command, spawnConfig.args, {
       env: process.env,
@@ -386,17 +435,38 @@ export class CodexAppServerClient {
       this.child = undefined;
       this.initialized = undefined;
     });
+  }
 
-    return this.requestRaw("initialize", {
-      clientInfo: {
-        name: "codex-relay",
-        title: "Codex Relay Mobile Server",
-        version: "1.2.0",
-      },
-      capabilities: {
-        experimentalApi: true,
-      },
-    }).then(() => undefined);
+  private async connectSharedCodexAppServer() {
+    const socket = new WebSocket(`ws+unix://${sharedCodexAppServerSocketPath()}:/`, {
+      perMessageDeflate: false,
+    });
+    this.socket = socket;
+    await new Promise<void>((resolve, reject) => {
+      const handleOpen = () => {
+        socket.off("error", handleInitialError);
+        resolve();
+      };
+      const handleInitialError = (error: Error) => {
+        socket.off("open", handleOpen);
+        reject(error);
+      };
+      socket.once("open", handleOpen);
+      socket.once("error", handleInitialError);
+    });
+    socket.on("message", (data) => this.handleLine(String(data)));
+    socket.on("error", (error) => this.rejectAll(error));
+    socket.once("close", (code, reason) => {
+      this.rejectAll(
+        new Error(
+          `Codex app-server socket closed with ${code}${reason.length > 0 ? `: ${String(reason)}` : "."}`,
+        ),
+      );
+      this.socket = undefined;
+      this.sharedServer?.kill();
+      this.sharedServer = undefined;
+      this.initialized = undefined;
+    });
   }
 
   private requestRaw<T>(method: string, params: unknown): Promise<T> {
@@ -405,9 +475,8 @@ export class CodexAppServerClient {
     debugAppServer("request", method, id);
     return new Promise<T>((resolve, reject) => {
       this.pending.set(id, { method, resolve: (value) => resolve(value as T), reject });
-      this.child!.stdin.write(`${request}\n`, (error) => {
-        if (error) {
-          this.pending.delete(id);
+      void this.writeSerializedJson(request).catch((error: Error) => {
+        if (this.pending.delete(id)) {
           reject(error);
         }
       });
@@ -464,12 +533,26 @@ export class CodexAppServerClient {
   }
 
   private writeJson(payload: unknown) {
+    return this.writeSerializedJson(JSON.stringify(payload));
+  }
+
+  private writeSerializedJson(payload: string) {
     return new Promise<void>((resolve, reject) => {
+      if (this.socket) {
+        this.socket.send(payload, (error) => {
+          if (error) {
+            reject(error);
+          } else {
+            resolve();
+          }
+        });
+        return;
+      }
       if (!this.child?.stdin) {
         reject(new Error("Codex app-server is not running."));
         return;
       }
-      this.child.stdin.write(`${JSON.stringify(payload)}\n`, (error) => {
+      this.child.stdin.write(`${payload}\n`, (error) => {
         if (error) {
           reject(error);
         } else {
@@ -485,6 +568,60 @@ export class CodexAppServerClient {
     }
     this.pending.clear();
   }
+}
+
+async function startSharedCodexAppServer() {
+  const spawnConfig = resolveCodexSharedAppServerSpawn();
+  const child = spawn(spawnConfig.command, spawnConfig.args, {
+    env: process.env,
+    shell: spawnConfig.shell,
+    windowsHide: spawnConfig.windowsHide,
+  });
+  let spawnError: Error | undefined;
+  let exitReason: NodeJS.Signals | number | undefined;
+  let stderr = "";
+  child.stdout.resume();
+  child.stderr.on("data", (chunk) => {
+    if (stderr.length < 8_192) {
+      stderr += String(chunk).slice(0, 8_192 - stderr.length);
+    }
+  });
+  child.once("error", (error) => {
+    spawnError = error;
+  });
+  child.once("exit", (code, signal) => {
+    exitReason = signal ?? code ?? 1;
+  });
+
+  const socketPath = sharedCodexAppServerSocketPath();
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    if (spawnError) {
+      throw new Error(`Failed to start the shared Codex app-server: ${spawnError.message}`);
+    }
+    try {
+      await access(socketPath);
+      return child;
+    } catch {
+      if (exitReason !== undefined) {
+        const detail = stderr.trim();
+        throw new Error(
+          `Failed to start the shared Codex app-server (exit ${exitReason})${detail ? `: ${detail}` : "."}`,
+        );
+      }
+      await setTimeout(25);
+    }
+  }
+
+  child.kill();
+  throw new Error(`Timed out waiting for the shared Codex app-server socket at ${socketPath}.`);
+}
+
+function sharedCodexAppServerSocketPath() {
+  return join(
+    process.env.CODEX_HOME?.trim() || join(homedir(), ".codex"),
+    "app-server-control",
+    "app-server-control.sock",
+  );
 }
 
 function debugAppServer(kind: string, method: string | undefined, id?: number, detail?: string) {

--- a/packages/codex-relay/src/cli.ts
+++ b/packages/codex-relay/src/cli.ts
@@ -38,6 +38,10 @@ const program = new Command()
   .option("--bg", "run the Codex Relay server in the background")
   .option("--debug", "write verbose relay diagnostics to debug.log")
   .option(
+    "--shared-app-server",
+    "use a shared Codex app-server socket so terminal and mobile can share live sessions",
+  )
+  .option(
     "--dangerously-auto-approve",
     "automatically approve mobile pairing requests without a local approval command",
   )
@@ -47,6 +51,7 @@ const program = new Command()
 
 Examples:
   ${npxCommand}              Start the relay and print a pairing QR
+  ${npxCommand} --shared-app-server Share live sessions with a connected terminal
   ${npxCommand} --bg         Start the relay in the background
   ${npxCommand} qr           Print the current pairing QR
   ${npxCommand} clear        Sign out every paired mobile app
@@ -58,6 +63,9 @@ Examples:
     }
     if (options.dangerouslyAutoApprove) {
       process.env.CODEX_RELAY_DANGEROUSLY_AUTO_APPROVE = "1";
+    }
+    if (options.sharedAppServer) {
+      process.env.CODEX_RELAY_APP_SERVER_MODE = "socket";
     }
 
     if (options.bg) {

--- a/packages/codex-relay/src/codex-binary.ts
+++ b/packages/codex-relay/src/codex-binary.ts
@@ -1,7 +1,8 @@
 import { platform as currentPlatform } from "node:os";
 import { extname } from "node:path";
 
-const appServerArgs = ["app-server", "--listen", "stdio://"] as const;
+const stdioAppServerArgs = ["app-server", "--listen", "stdio://"] as const;
+const sharedServerArgs = ["app-server", "--listen", "unix://"] as const;
 const windowsShellExtensions = new Set([".bat", ".cmd"]);
 
 type CodexSpawnPlatform = NodeJS.Platform;
@@ -18,19 +19,59 @@ export type CodexAppServerSpawnInput = {
   readonly platform?: CodexSpawnPlatform;
 };
 
+export type CodexAppServerMode = "stdio" | "socket";
+
+export function resolveCodexAppServerMode(
+  env: NodeJS.ProcessEnv = process.env,
+): CodexAppServerMode {
+  const configuredMode = env.CODEX_RELAY_APP_SERVER_MODE?.trim().toLowerCase();
+  if (!configuredMode || configuredMode === "stdio") {
+    return "stdio";
+  }
+  if (configuredMode === "socket") {
+    return "socket";
+  }
+  throw new Error(
+    `Unsupported CODEX_RELAY_APP_SERVER_MODE ${JSON.stringify(configuredMode)}. Expected "stdio" or "socket".`,
+  );
+}
+
 export function resolveCodexAppServerSpawn(
   input: CodexAppServerSpawnInput = {},
 ): CodexAppServerSpawn {
   const platform = input.platform ?? currentPlatform();
+  const env = input.env ?? process.env;
+  const command = resolveCodexBinary(env);
+  const isWindows = platform === "win32";
+
+  return {
+    command,
+    args: [...stdioAppServerArgs],
+    shell: isWindows && shouldUseWindowsShell(command),
+    windowsHide: isWindows,
+  };
+}
+
+export function resolveCodexSharedAppServerSpawn(
+  input: CodexAppServerSpawnInput = {},
+): CodexAppServerSpawn {
+  const platform = input.platform ?? currentPlatform();
+  assertAppServerModeSupported("socket", platform);
   const command = resolveCodexBinary(input.env ?? process.env);
   const isWindows = platform === "win32";
 
   return {
     command,
-    args: [...appServerArgs],
+    args: [...sharedServerArgs],
     shell: isWindows && shouldUseWindowsShell(command),
     windowsHide: isWindows,
   };
+}
+
+function assertAppServerModeSupported(mode: CodexAppServerMode, platform: CodexSpawnPlatform) {
+  if (mode === "socket" && platform === "win32") {
+    throw new Error("Shared Codex app-server mode requires macOS, Linux, or WSL.");
+  }
 }
 
 function resolveCodexBinary(env: NodeJS.ProcessEnv) {

--- a/packages/codex-relay/src/index.ts
+++ b/packages/codex-relay/src/index.ts
@@ -7,6 +7,8 @@ import pc from "picocolors";
 import qrcode from "qrcode-terminal";
 
 import { createApp } from "./app.js";
+import { CodexAppServerClient } from "./app-server.js";
+import { resolveCodexAppServerMode } from "./codex-binary.js";
 import { isRelayDebugEnabled, relayDebugLog } from "./debug-log.js";
 import {
   createPairingQrPayload,
@@ -55,10 +57,19 @@ const sessionStore = await createTursoPairingSessionStore(
 const preferencesStore = createFileRuntimePreferencesStore(
   process.env.CODEX_RELAY_PREFERENCES_PATH ?? (await prepareCodexRelayDataPath("preferences.json")),
 );
+const appServerMode = resolveCodexAppServerMode();
+const sharedAppServer = appServerMode === "socket" ? new CodexAppServerClient() : undefined;
+if (sharedAppServer) {
+  await sharedAppServer.initialize();
+  process.once("SIGINT", () => stopSharedAppServer(130));
+  process.once("SIGTERM", () => stopSharedAppServer(143));
+  process.once("exit", () => sharedAppServer.close());
+}
 
 serve(
   {
     fetch: createApp({
+      appServer: sharedAppServer,
       pairing: {
         approvalSecret,
         dangerouslyAutoApprove,
@@ -152,10 +163,16 @@ serve(
         listenUrl,
         pairingPayload,
         port: info.port,
+        sharedAppServer: appServerMode === "socket",
       }),
     );
   },
 );
+
+function stopSharedAppServer(exitCode: number) {
+  sharedAppServer?.close();
+  process.exit(exitCode);
+}
 
 function formatStartupInstructions(details: {
   connectUrl: string;
@@ -164,6 +181,7 @@ function formatStartupInstructions(details: {
   listenUrl: string;
   pairingPayload: string;
   port: number;
+  sharedAppServer: boolean;
 }) {
   const lines = [
     `${color.prompt("›")} Scan the QR code above to pair ${color.brand("Codex Relay mobile")}.`,
@@ -174,6 +192,13 @@ function formatStartupInstructions(details: {
     `${color.prompt("›")} Server: ${color.muted(details.listenUrl)}`,
     "",
     `${color.prompt("›")} Pairing: ${color.url(details.pairingPayload)}`,
+    ...(details.sharedAppServer
+      ? [
+          "",
+          `${color.prompt("›")} Terminal: ${color.command("codex resume --remote unix://")}`,
+          `  ${color.muted("Connect through the shared Codex app-server to follow and steer the same live sessions.")}`,
+        ]
+      : []),
     "",
     `${color.prompt("›")} Commands`,
     `  ${color.command(npxCommand)}              Start and print a pairing QR`,

--- a/packages/codex-relay/test/codex-binary.test.ts
+++ b/packages/codex-relay/test/codex-binary.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { resolveCodexAppServerSpawn } from "../src/codex-binary.js";
+import {
+  resolveCodexAppServerMode,
+  resolveCodexAppServerSpawn,
+  resolveCodexSharedAppServerSpawn,
+} from "../src/codex-binary.js";
 
 describe("Codex app-server spawn resolution", () => {
   it("uses a shell for the default npm command on Windows", () => {
@@ -57,5 +61,29 @@ describe("Codex app-server spawn resolution", () => {
       shell: false,
       windowsHide: false,
     });
+  });
+
+  it("listens on the shared Unix socket in shared mode", () => {
+    expect(resolveCodexSharedAppServerSpawn({ env: {}, platform: "linux" })).toEqual({
+      command: "codex",
+      args: ["app-server", "--listen", "unix://"],
+      shell: false,
+      windowsHide: false,
+    });
+  });
+
+  it("rejects unknown app-server modes", () => {
+    expect(() => resolveCodexAppServerMode({ CODEX_RELAY_APP_SERVER_MODE: "shared" })).toThrow(
+      'Expected "stdio" or "socket"',
+    );
+  });
+
+  it("rejects shared socket mode on native Windows", () => {
+    expect(() =>
+      resolveCodexSharedAppServerSpawn({
+        env: { CODEX_RELAY_APP_SERVER_MODE: "socket" },
+        platform: "win32",
+      }),
+    ).toThrow("requires macOS, Linux, or WSL");
   });
 });

--- a/packages/codex-relay/test/live-mobile-stream-contract.test.ts
+++ b/packages/codex-relay/test/live-mobile-stream-contract.test.ts
@@ -1,7 +1,7 @@
 import { mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { createApp } from "../src/app.js";
 import { CodexAppServerClient } from "../src/app-server.js";
@@ -21,6 +21,7 @@ const liveDescribe = runLiveAppServerTest ? describe : describe.skip;
 
 liveDescribe("live mobile stream contract", () => {
   let appServer: CodexAppServerClient | undefined;
+  let secondAppServer: CodexAppServerClient | undefined;
 
   beforeEach(() => {
     resetChatSessionState();
@@ -28,8 +29,42 @@ liveDescribe("live mobile stream contract", () => {
 
   afterEach(() => {
     appServer?.close();
+    secondAppServer?.close();
     appServer = undefined;
+    secondAppServer = undefined;
+    vi.unstubAllEnvs();
   });
+
+  it("shares a socket-backed thread between independent app-server clients", async () => {
+    const workspacePath = await mkdtemp(join(tmpdir(), "codex-relay-shared-workspace-"));
+    vi.stubEnv("CODEX_RELAY_APP_SERVER_MODE", "socket");
+    appServer = new CodexAppServerClient();
+    secondAppServer = new CodexAppServerClient();
+    await Promise.all([appServer.initialize(), secondAppServer.initialize()]);
+    const secondClientNotifications: string[] = [];
+    const unsubscribe = secondAppServer.onNotification((notification) => {
+      secondClientNotifications.push(notification.method);
+    });
+
+    const thread = await appServer.startThread({
+      approvalPolicy: "never",
+      cwd: workspacePath,
+      experimentalRawEvents: false,
+      model: null,
+      persistExtendedHistory: true,
+      sandbox: "read-only",
+      serviceTier: null,
+    });
+
+    try {
+      await vi.waitFor(() => expect(secondClientNotifications).toContain("thread/started"));
+      const sharedThread = await secondAppServer.readThread(thread.id, { includeTurns: false });
+      expect(sharedThread.id).toBe(thread.id);
+      expect(sharedThread.cwd).toBe(workspacePath);
+    } finally {
+      unsubscribe();
+    }
+  }, 30_000);
 
   it("round-trips a real app-server turn through the server SSE and mobile stream reducer", async () => {
     const workspacePath = await mkdtemp(join(tmpdir(), "codex-relay-live-workspace-"));


### PR DESCRIPTION
## Summary

- add an opt-in `--shared-app-server` mode that runs Codex on its local Unix-socket transport
- connect the relay directly over WebSocket while allowing a terminal TUI to attach with `codex resume --remote unix://`
- preserve the existing private stdio app-server as the default and reject unsupported native Windows shared mode with clear guidance
- document session handoff, startup instructions, requirements, and lifecycle behavior

## Why

Codex Relay currently launches a private `codex app-server --listen stdio://` child. A separately launched terminal TUI can read the same persisted thread, but it is attached to a different in-memory event stream, so mobile turns do not appear live in that terminal.

Shared mode puts the relay and remote-aware terminal clients on the same Codex Unix-socket app-server. The relay owns the listener lifecycle, performs the WebSocket handshake expected by Codex's Unix transport, and cleans up the listener on shutdown.

The mode is opt-in so existing installs and workflows remain unchanged.

## Validation

- [x] `pnpm build`
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test` (239 passed, 4 skipped)
- [x] live two-client Codex contract: both clients initialize, the second receives `thread/started`, and it reads the thread created by the first
- [x] packaged CLI smoke: shared startup banner prints the attach command and SIGTERM leaves no listener or socket behind

## Notes

- Shared mode requires a recent Codex CLI with Unix-socket app-server and `resume --remote` support.
- Native Windows should use WSL or the default private stdio mode.
- An already-running standalone TUI cannot be upgraded in place; it must reconnect through `--remote`.

Closes #17
