### PR TITLE
fix: recover shared app-server sockets

### DIFF
--- a/.changeset/soft-coins-vanish.md
+++ b/.changeset/soft-coins-vanish.md
@@ -1,0 +1,5 @@
+---
+"codex-relay": patch
+---
+
+Reconnect to a shared app-server socket after a local transport reset without stopping the shared server.

--- a/.changeset/soft-coins-vanish.md
+++ b/.changeset/soft-coins-vanish.md
@@ -2,4 +2,4 @@
 "codex-relay": patch
 ---
 
-Reconnect to a shared app-server socket after a local transport reset without stopping the shared server.
+Reconnect to a shared app-server socket after a local transport reset without deliberately stopping the shared server, with ownership diagnostics and terminal recovery guidance.

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ The default relay uses its own Codex app-server process. To make mobile and a te
 npx codex-relay@latest --shared-app-server
 ```
 
-When a shared app-server is already running, the relay attaches to it instead of starting another one. If the relay's own socket connection resets, it reconnects without stopping the shared app-server or other connected clients.
+When a shared app-server is already running, the relay attaches to it instead of starting another one. If the relay's own socket connection resets, it reconnects without deliberately stopping the shared app-server.
 
 Then attach a new terminal TUI:
 
@@ -107,6 +107,12 @@ codex resume --remote unix://
 ```
 
 An already-running standalone TUI cannot be converted in place. Exit it and reconnect with `--remote`. Shared mode requires a recent Codex CLI with Unix-socket app-server and remote-resume support; native Windows should use WSL or the default private mode.
+
+Shared mode uses Codex's experimental app-server transport. A directly connected terminal TUI has its own WebSocket connection, which the relay cannot observe or reconnect. If that terminal reports a socket reset while the thread continues on mobile, reconnect it with:
+
+```sh
+codex resume --remote unix:// <thread-id>
+```
 
 ## Network Setup
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ The default relay uses its own Codex app-server process. To make mobile and a te
 npx codex-relay@latest --shared-app-server
 ```
 
+When a shared app-server is already running, the relay attaches to it instead of starting another one. If the relay's own socket connection resets, it reconnects without stopping the shared app-server or other connected clients.
+
 Then attach a new terminal TUI:
 
 ```sh

--- a/packages/codex-relay/README.md
+++ b/packages/codex-relay/README.md
@@ -38,7 +38,7 @@ On macOS, Linux, or WSL, opt in to Codex's shared app-server socket:
 npx codex-relay@latest --shared-app-server
 ```
 
-When a shared app-server is already running, the relay attaches to it instead of starting another one. If the relay's own socket connection resets, it reconnects without stopping the shared app-server or other connected clients.
+When a shared app-server is already running, the relay attaches to it instead of starting another one. If the relay's own socket connection resets, it reconnects without deliberately stopping the shared app-server.
 
 Then connect a new terminal TUI to the shared app-server socket:
 
@@ -47,6 +47,12 @@ codex resume --remote unix://
 ```
 
 Pass a thread ID after `unix://` to open a specific thread. The relay prints the attach command at startup. Mobile and the connected terminal can then observe the same live sessions through one socket-backed app-server. An already-running standalone TUI cannot be converted in place; exit it and reconnect with `--remote`.
+
+Shared mode uses Codex's experimental app-server transport. A directly connected terminal TUI has its own WebSocket connection, which the relay cannot observe or reconnect. If that terminal reports a socket reset while the thread continues on mobile, reconnect it with:
+
+```sh
+codex resume --remote unix:// <thread-id>
+```
 
 Shared mode requires a recent Codex CLI with Unix-socket app-server and `resume --remote` support. If those features are unavailable, update Codex or omit `--shared-app-server` to keep the existing private mode. Native Windows is not currently supported; use WSL or private mode there.
 

--- a/packages/codex-relay/README.md
+++ b/packages/codex-relay/README.md
@@ -38,6 +38,8 @@ On macOS, Linux, or WSL, opt in to Codex's shared app-server socket:
 npx codex-relay@latest --shared-app-server
 ```
 
+When a shared app-server is already running, the relay attaches to it instead of starting another one. If the relay's own socket connection resets, it reconnects without stopping the shared app-server or other connected clients.
+
 Then connect a new terminal TUI to the shared app-server socket:
 
 ```sh

--- a/packages/codex-relay/src/app-server.ts
+++ b/packages/codex-relay/src/app-server.ts
@@ -30,6 +30,8 @@ type PendingRequest = {
   resolve(value: unknown): void;
 };
 
+type SharedAppServerOwnership = "attached" | "relay-owned";
+
 export type CodexAppServerClientOptions = {
   startSharedServer?: () => Promise<ChildProcessWithoutNullStreams>;
 };
@@ -475,6 +477,7 @@ export class CodexAppServerClient {
     try {
       await this.connectSharedCodexAppServer();
       relayDebugLog("app_server.shared_socket.attached", {
+        ownership: "attached",
         socketPath: sharedCodexAppServerSocketPath(),
       });
       return;
@@ -492,6 +495,10 @@ export class CodexAppServerClient {
     const sharedServer = await this.startSharedServer();
     this.sharedServer = sharedServer;
     this.observeSharedCodexAppServer(sharedServer);
+    relayDebugLog("app_server.shared_process.started", {
+      ownership: "relay-owned",
+      socketPath: sharedCodexAppServerSocketPath(),
+    });
     try {
       await this.connectSharedCodexAppServer();
     } catch (error) {
@@ -505,7 +512,10 @@ export class CodexAppServerClient {
 
   private observeSharedCodexAppServer(sharedServer: ChildProcessWithoutNullStreams) {
     sharedServer.on("error", (error) => {
-      relayDebugLog("app_server.shared_process.error", { message: error.message });
+      relayDebugLog("app_server.shared_process.error", {
+        message: error.message,
+        ownership: "relay-owned",
+      });
       if (this.sharedServer === sharedServer) {
         this.sharedServer = undefined;
       }
@@ -516,7 +526,10 @@ export class CodexAppServerClient {
       }
       this.sharedServer = undefined;
       const error = new Error(`Codex shared app-server exited with ${signal ?? code ?? 1}.`);
-      relayDebugLog("app_server.shared_process.exited", { message: error.message });
+      relayDebugLog("app_server.shared_process.exited", {
+        message: error.message,
+        ownership: "relay-owned",
+      });
       if (this.socket) {
         this.handleSharedSocketFailure(this.socket, error);
       }
@@ -559,6 +572,7 @@ export class CodexAppServerClient {
       );
     });
     relayDebugLog("app_server.shared_socket.connected", {
+      ownership: this.sharedAppServerOwnership(),
       socketPath: sharedCodexAppServerSocketPath(),
     });
   }
@@ -570,8 +584,15 @@ export class CodexAppServerClient {
     this.socket = undefined;
     this.rejectAll(error);
     this.initialized = undefined;
-    relayDebugLog("app_server.shared_socket.disconnected", { message: error.message });
+    relayDebugLog("app_server.shared_socket.disconnected", {
+      message: error.message,
+      ownership: this.sharedAppServerOwnership(),
+    });
     this.scheduleSharedSocketReconnect();
+  }
+
+  private sharedAppServerOwnership(): SharedAppServerOwnership {
+    return this.sharedServer ? "relay-owned" : "attached";
   }
 
   private scheduleSharedSocketReconnect() {
@@ -591,6 +612,7 @@ export class CodexAppServerClient {
         const reconnectError = asError(error);
         relayDebugLog("app_server.shared_socket.reconnect_failed", {
           message: reconnectError.message,
+          ownership: this.sharedAppServerOwnership(),
         });
         if (this.initialized === reconnecting) {
           this.initialized = undefined;
@@ -613,6 +635,7 @@ export class CodexAppServerClient {
         await this.connectSharedCodexAppServer();
         await this.initializeAppServer();
         relayDebugLog("app_server.shared_socket.reconnected", {
+          ownership: this.sharedAppServerOwnership(),
           socketPath: sharedCodexAppServerSocketPath(),
         });
         return;
@@ -624,6 +647,7 @@ export class CodexAppServerClient {
         relayDebugLog("app_server.shared_socket.reconnect_retry", {
           delayMs,
           message: lastError.message,
+          ownership: this.sharedAppServerOwnership(),
         });
       }
     }

--- a/packages/codex-relay/src/app-server.ts
+++ b/packages/codex-relay/src/app-server.ts
@@ -11,6 +11,7 @@ import {
   resolveCodexAppServerSpawn,
   resolveCodexSharedAppServerSpawn,
 } from "./codex-binary.js";
+import { relayDebugLog } from "./debug-log.js";
 
 type JsonRpcServerMessage = {
   id?: number;
@@ -28,6 +29,12 @@ type PendingRequest = {
   reject(error: Error): void;
   resolve(value: unknown): void;
 };
+
+export type CodexAppServerClientOptions = {
+  startSharedServer?: () => Promise<ChildProcessWithoutNullStreams>;
+};
+
+const sharedSocketReconnectDelaysMs = [50, 100, 250, 500, 1_000, 2_000] as const;
 
 export type AppServerThread = {
   id: string;
@@ -245,14 +252,21 @@ export type AppServerThreadGoalClearParams = {
 
 export class CodexAppServerClient {
   private child: ChildProcessWithoutNullStreams | undefined;
+  private closed = false;
   private initialized: Promise<void> | undefined;
   private notificationHandlers = new Set<(notification: AppServerNotification) => void>();
   private nextId = 1;
   private pending = new Map<number, PendingRequest>();
+  private reconnecting: Promise<void> | undefined;
   private requestHandlers = new Set<(request: AppServerRequest) => void>();
   private readline: Interface | undefined;
   private sharedServer: ChildProcessWithoutNullStreams | undefined;
   private socket: WebSocket | undefined;
+  private startSharedServer: () => Promise<ChildProcessWithoutNullStreams>;
+
+  constructor(options: CodexAppServerClientOptions = {}) {
+    this.startSharedServer = options.startSharedServer ?? startSharedCodexAppServer;
+  }
 
   initialize() {
     return this.ensureInitialized();
@@ -348,17 +362,22 @@ export class CodexAppServerClient {
   }
 
   close() {
+    if (this.closed) {
+      return;
+    }
+    this.closed = true;
     for (const pending of this.pending.values()) {
       pending.reject(new Error("Codex app-server was closed."));
     }
     this.pending.clear();
     this.readline?.close();
     this.child?.kill();
-    this.socket?.close();
+    const socket = this.socket;
+    this.socket = undefined;
+    socket?.close();
     this.sharedServer?.kill();
     this.readline = undefined;
     this.child = undefined;
-    this.socket = undefined;
     this.sharedServer = undefined;
     this.initialized = undefined;
   }
@@ -378,41 +397,49 @@ export class CodexAppServerClient {
   }
 
   private ensureInitialized() {
+    if (this.closed) {
+      return Promise.reject(new Error("Codex app-server was closed."));
+    }
     if (!this.initialized) {
-      this.initialized = this.start();
+      const initialized = this.start();
+      this.initialized = initialized;
+      void initialized.catch(() => {
+        if (this.initialized === initialized) {
+          this.initialized = undefined;
+        }
+      });
     }
     return this.initialized;
   }
 
   private async start() {
+    const mode = resolveCodexAppServerMode();
     try {
-      if (resolveCodexAppServerMode() === "socket") {
-        this.sharedServer = await startSharedCodexAppServer();
-        await this.connectSharedCodexAppServer();
+      if (mode === "socket") {
+        await this.startOrAttachSharedCodexAppServer();
       } else {
         this.startStdioCodexAppServer();
       }
-      await this.requestRaw("initialize", {
-        clientInfo: {
-          name: "codex-relay",
-          title: "Codex Relay Mobile Server",
-          version: "1.2.0",
-        },
-        capabilities: {
-          experimentalApi: true,
-        },
-      });
+      await this.initializeAppServer();
     } catch (error) {
-      this.readline?.close();
-      this.readline = undefined;
-      this.child?.kill();
-      this.child = undefined;
-      this.socket?.close();
-      this.socket = undefined;
-      this.sharedServer?.kill();
-      this.sharedServer = undefined;
+      if (mode === "stdio") {
+        this.stopStdioCodexAppServer();
+      }
       throw error;
     }
+  }
+
+  private async initializeAppServer() {
+    await this.requestRaw("initialize", {
+      clientInfo: {
+        name: "codex-relay",
+        title: "Codex Relay Mobile Server",
+        version: "1.2.0",
+      },
+      capabilities: {
+        experimentalApi: true,
+      },
+    });
   }
 
   private startStdioCodexAppServer() {
@@ -437,36 +464,170 @@ export class CodexAppServerClient {
     });
   }
 
+  private stopStdioCodexAppServer() {
+    this.readline?.close();
+    this.readline = undefined;
+    this.child?.kill();
+    this.child = undefined;
+  }
+
+  private async startOrAttachSharedCodexAppServer() {
+    try {
+      await this.connectSharedCodexAppServer();
+      relayDebugLog("app_server.shared_socket.attached", {
+        socketPath: sharedCodexAppServerSocketPath(),
+      });
+      return;
+    } catch (error) {
+      const attachError = asError(error);
+      relayDebugLog("app_server.shared_socket.attach_failed", {
+        message: attachError.message,
+        socketPath: sharedCodexAppServerSocketPath(),
+      });
+      if (this.sharedServer) {
+        throw attachError;
+      }
+    }
+
+    const sharedServer = await this.startSharedServer();
+    this.sharedServer = sharedServer;
+    this.observeSharedCodexAppServer(sharedServer);
+    try {
+      await this.connectSharedCodexAppServer();
+    } catch (error) {
+      if (this.sharedServer === sharedServer) {
+        sharedServer.kill();
+        this.sharedServer = undefined;
+      }
+      throw error;
+    }
+  }
+
+  private observeSharedCodexAppServer(sharedServer: ChildProcessWithoutNullStreams) {
+    sharedServer.on("error", (error) => {
+      relayDebugLog("app_server.shared_process.error", { message: error.message });
+      if (this.sharedServer === sharedServer) {
+        this.sharedServer = undefined;
+      }
+    });
+    sharedServer.once("exit", (code, signal) => {
+      if (this.sharedServer !== sharedServer) {
+        return;
+      }
+      this.sharedServer = undefined;
+      const error = new Error(`Codex shared app-server exited with ${signal ?? code ?? 1}.`);
+      relayDebugLog("app_server.shared_process.exited", { message: error.message });
+      if (this.socket) {
+        this.handleSharedSocketFailure(this.socket, error);
+      }
+    });
+  }
+
   private async connectSharedCodexAppServer() {
     const socket = new WebSocket(`ws+unix://${sharedCodexAppServerSocketPath()}:/`, {
       perMessageDeflate: false,
     });
     this.socket = socket;
-    await new Promise<void>((resolve, reject) => {
-      const handleOpen = () => {
-        socket.off("error", handleInitialError);
-        resolve();
-      };
-      const handleInitialError = (error: Error) => {
-        socket.off("open", handleOpen);
-        reject(error);
-      };
-      socket.once("open", handleOpen);
-      socket.once("error", handleInitialError);
-    });
+    try {
+      await new Promise<void>((resolve, reject) => {
+        const handleOpen = () => {
+          socket.off("error", handleInitialError);
+          resolve();
+        };
+        const handleInitialError = (error: Error) => {
+          socket.off("open", handleOpen);
+          reject(error);
+        };
+        socket.once("open", handleOpen);
+        socket.once("error", handleInitialError);
+      });
+    } catch (error) {
+      if (this.socket === socket) {
+        this.socket = undefined;
+      }
+      socket.close();
+      throw error;
+    }
     socket.on("message", (data) => this.handleLine(String(data)));
-    socket.on("error", (error) => this.rejectAll(error));
+    socket.on("error", (error) => this.handleSharedSocketFailure(socket, error));
     socket.once("close", (code, reason) => {
-      this.rejectAll(
+      this.handleSharedSocketFailure(
+        socket,
         new Error(
           `Codex app-server socket closed with ${code}${reason.length > 0 ? `: ${String(reason)}` : "."}`,
         ),
       );
-      this.socket = undefined;
-      this.sharedServer?.kill();
-      this.sharedServer = undefined;
-      this.initialized = undefined;
     });
+    relayDebugLog("app_server.shared_socket.connected", {
+      socketPath: sharedCodexAppServerSocketPath(),
+    });
+  }
+
+  private handleSharedSocketFailure(socket: WebSocket, error: Error) {
+    if (this.socket !== socket) {
+      return;
+    }
+    this.socket = undefined;
+    this.rejectAll(error);
+    this.initialized = undefined;
+    relayDebugLog("app_server.shared_socket.disconnected", { message: error.message });
+    this.scheduleSharedSocketReconnect();
+  }
+
+  private scheduleSharedSocketReconnect() {
+    if (this.closed || this.reconnecting) {
+      return;
+    }
+    const reconnecting = this.reconnectSharedCodexAppServer();
+    this.reconnecting = reconnecting;
+    this.initialized = reconnecting;
+    void reconnecting.then(
+      () => {
+        if (this.reconnecting === reconnecting) {
+          this.reconnecting = undefined;
+        }
+      },
+      (error: unknown) => {
+        const reconnectError = asError(error);
+        relayDebugLog("app_server.shared_socket.reconnect_failed", {
+          message: reconnectError.message,
+        });
+        if (this.initialized === reconnecting) {
+          this.initialized = undefined;
+        }
+        if (this.reconnecting === reconnecting) {
+          this.reconnecting = undefined;
+        }
+      },
+    );
+  }
+
+  private async reconnectSharedCodexAppServer() {
+    let lastError: Error | undefined;
+    for (const delayMs of sharedSocketReconnectDelaysMs) {
+      await setTimeout(delayMs);
+      if (this.closed) {
+        return;
+      }
+      try {
+        await this.connectSharedCodexAppServer();
+        await this.initializeAppServer();
+        relayDebugLog("app_server.shared_socket.reconnected", {
+          socketPath: sharedCodexAppServerSocketPath(),
+        });
+        return;
+      } catch (error) {
+        lastError = asError(error);
+        const socket = this.socket;
+        this.socket = undefined;
+        socket?.close();
+        relayDebugLog("app_server.shared_socket.reconnect_retry", {
+          delayMs,
+          message: lastError.message,
+        });
+      }
+    }
+    throw lastError ?? new Error("Unable to reconnect to the shared Codex app-server.");
   }
 
   private requestRaw<T>(method: string, params: unknown): Promise<T> {
@@ -622,6 +783,10 @@ function sharedCodexAppServerSocketPath() {
     "app-server-control",
     "app-server-control.sock",
   );
+}
+
+function asError(error: unknown) {
+  return error instanceof Error ? error : new Error(String(error));
 }
 
 function debugAppServer(kind: string, method: string | undefined, id?: number, detail?: string) {

--- a/packages/codex-relay/test/app-server.test.ts
+++ b/packages/codex-relay/test/app-server.test.ts
@@ -5,7 +5,12 @@ import { dirname, join } from "node:path";
 import { WebSocketServer, type WebSocket } from "ws";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+vi.mock("../src/debug-log.js", () => ({
+  relayDebugLog: vi.fn<(event: string, fields?: Record<string, unknown>) => void>(),
+}));
+
 import { CodexAppServerClient } from "../src/app-server.js";
+import { relayDebugLog } from "../src/debug-log.js";
 
 type JsonRpcRequest = {
   id: number;
@@ -20,6 +25,7 @@ type SharedSocketServer = {
 
 describe("CodexAppServerClient shared socket mode", () => {
   afterEach(() => {
+    vi.clearAllMocks();
     vi.unstubAllEnvs();
   });
 
@@ -38,6 +44,14 @@ describe("CodexAppServerClient shared socket mode", () => {
       await client.initialize();
       expect(server.connections).toHaveLength(1);
       expect(startSharedServer).not.toHaveBeenCalled();
+      expect(relayDebugLog).toHaveBeenCalledWith("app_server.shared_socket.connected", {
+        ownership: "attached",
+        socketPath,
+      });
+      expect(relayDebugLog).toHaveBeenCalledWith("app_server.shared_socket.attached", {
+        ownership: "attached",
+        socketPath,
+      });
 
       server.connections[0]?.terminate();
 
@@ -50,6 +64,14 @@ describe("CodexAppServerClient shared socket mode", () => {
       await expect(client.listModels()).resolves.toEqual([]);
       expect(server.requests.filter((request) => request.method === "initialize")).toHaveLength(2);
       expect(startSharedServer).not.toHaveBeenCalled();
+      expect(relayDebugLog).toHaveBeenCalledWith(
+        "app_server.shared_socket.disconnected",
+        expect.objectContaining({ ownership: "attached" }),
+      );
+      expect(relayDebugLog).toHaveBeenCalledWith("app_server.shared_socket.reconnected", {
+        ownership: "attached",
+        socketPath,
+      });
     } finally {
       client.close();
       await server.close();

--- a/packages/codex-relay/test/app-server.test.ts
+++ b/packages/codex-relay/test/app-server.test.ts
@@ -1,0 +1,116 @@
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { createServer, type Server } from "node:http";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { WebSocketServer, type WebSocket } from "ws";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { CodexAppServerClient } from "../src/app-server.js";
+
+type JsonRpcRequest = {
+  id: number;
+  method: string;
+};
+
+type SharedSocketServer = {
+  close: () => Promise<void>;
+  connections: WebSocket[];
+  requests: JsonRpcRequest[];
+};
+
+describe("CodexAppServerClient shared socket mode", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("reconnects after its shared socket resets without starting another app-server", async () => {
+    const codexHome = await mkdtemp(join(tmpdir(), "codex-relay-app-server-"));
+    const socketPath = join(codexHome, "app-server-control", "app-server-control.sock");
+    const server = await startSharedSocketServer(socketPath);
+    vi.stubEnv("CODEX_HOME", codexHome);
+    vi.stubEnv("CODEX_RELAY_APP_SERVER_MODE", "socket");
+    const startSharedServer = vi.fn<() => Promise<never>>(async () => {
+      throw new Error("Expected the client to attach to the existing shared app-server.");
+    });
+    const client = new CodexAppServerClient({ startSharedServer });
+
+    try {
+      await client.initialize();
+      expect(server.connections).toHaveLength(1);
+      expect(startSharedServer).not.toHaveBeenCalled();
+
+      server.connections[0]?.terminate();
+
+      await vi.waitFor(
+        () => {
+          expect(server.connections).toHaveLength(2);
+        },
+        { timeout: 5_000 },
+      );
+      await expect(client.listModels()).resolves.toEqual([]);
+      expect(server.requests.filter((request) => request.method === "initialize")).toHaveLength(2);
+      expect(startSharedServer).not.toHaveBeenCalled();
+    } finally {
+      client.close();
+      await server.close();
+      await rm(codexHome, { force: true, recursive: true });
+    }
+  });
+});
+
+async function startSharedSocketServer(socketPath: string): Promise<SharedSocketServer> {
+  await mkdir(dirname(socketPath), { recursive: true });
+  const connections: WebSocket[] = [];
+  const requests: JsonRpcRequest[] = [];
+  const server = createServer();
+  const webSocketServer = new WebSocketServer({ server });
+  webSocketServer.on("connection", (socket) => {
+    connections.push(socket);
+    socket.on("message", (data) => {
+      const request = JSON.parse(String(data)) as JsonRpcRequest;
+      requests.push(request);
+      socket.send(
+        JSON.stringify({
+          id: request.id,
+          result: request.method === "model/list" ? { data: [] } : {},
+        }),
+      );
+    });
+  });
+  await listen(server, socketPath);
+
+  return {
+    connections,
+    requests,
+    async close() {
+      for (const socket of connections) {
+        socket.terminate();
+      }
+      await new Promise<void>((resolve, reject) => {
+        webSocketServer.close((error) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+          server.close((serverError) => {
+            if (serverError) {
+              reject(serverError);
+              return;
+            }
+            resolve();
+          });
+        });
+      });
+    },
+  };
+}
+
+function listen(server: Server, socketPath: string) {
+  return new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(socketPath, () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- attach to an already-running shared app-server socket before starting a relay-owned listener
- reconnect the relay client after a shared-socket transport reset with bounded backoff
- avoid deliberately stopping the shared app-server when the relay's own socket disconnects
- tag shared-socket lifecycle diagnostics as `attached` or `relay-owned` under `--debug`
- document how to resume a directly connected terminal after its independent WebSocket resets
- add regression coverage, documentation, and a patch changeset

## Root cause

Shared mode treated the relay's WebSocket `close` event as a server shutdown and killed its `sharedServer` child. When the relay owned that child, a local transport reset could therefore disconnect an attached terminal client as well.

The relay now treats a socket reset as a client-connection failure: in-flight relay requests fail safely, then the relay reconnects and runs protocol initialisation again. It only stops a relay-owned child during an explicit relay shutdown.

## Scope

This prevents relay-induced app-server stops. A terminal TUI connected with `codex --remote` has its own WebSocket connection, which the relay cannot observe or reconnect. That connection can reset independently while the app-server, mobile client, and underlying thread continue running; resume the same thread with `codex resume --remote unix:// <thread-id>`.

## Why shared mode remains opt-in

Shared mode deliberately changes the default ownership and failure model from a private stdio app-server to a user-wide Unix socket that multiple clients can attach to. It also needs a recent Codex CLI with Unix-socket and remote-resume support, and native Windows remains unsupported.

This fix closes the concrete relay-induced reset path found while dogfooding, but keeping the feature opt-in gives us more lifecycle evidence before changing existing users' session semantics by default.

## Validation

- `pnpm --filter codex-relay test` - 240 passed, 4 skipped
- `pnpm --filter codex-relay typecheck`
- `pnpm lint` - zero warnings and errors
- `pnpm --filter codex-relay build`