### PR TITLE
fix: improve mobile project labels

### DIFF
--- a/.changeset/fancy-paws-pick.md
+++ b/.changeset/fancy-paws-pick.md
@@ -1,0 +1,5 @@
+---
+"@codex-relay/mobile": patch
+---
+
+fix: improve mobile project labels

--- a/apps/mobile/src/components/chat/ConnectionBanner.tsx
+++ b/apps/mobile/src/components/chat/ConnectionBanner.tsx
@@ -6,6 +6,7 @@ import { ThemedText } from "@/components/themed-text";
 import { Button } from "@/components/ui/button";
 import { Icon } from "@/components/ui/icon";
 import { Fonts } from "@/constants/theme";
+import { workspaceName } from "@/lib/workspace-name";
 
 const tailscaleAppStoreUrl = "https://apps.apple.com/us/app/tailscale/id1470499037";
 
@@ -225,14 +226,6 @@ function PairingStep({
       </View>
     </View>
   );
-}
-
-function workspaceName(workspacePath: string | undefined) {
-  if (!workspacePath) {
-    return undefined;
-  }
-  const parts = workspacePath.split("/").filter(Boolean);
-  return parts.at(-1);
 }
 
 function compactServer(serverUrl: string) {

--- a/apps/mobile/src/components/chat/ThreadDrawerContent.tsx
+++ b/apps/mobile/src/components/chat/ThreadDrawerContent.tsx
@@ -53,6 +53,7 @@ import {
   setThreadsState,
 } from "@/lib/server-state";
 import { evaluateRelayVersion, type RelayVersionCompatibility } from "@/lib/version-policy";
+import { workspaceName } from "@/lib/workspace-name";
 import {
   chatStore$,
   requestThreadStreamReconnect,
@@ -395,7 +396,6 @@ export function ThreadDrawerContent(props: ThreadDrawerContentProps) {
           data={rows}
           drawDistance={drawerListDrawDistance}
           estimatedItemSize={drawerRowEstimatedSize}
-          getFixedItemSize={getEstimatedDrawerRowSize}
           keyboardShouldPersistTaps="handled"
           keyExtractor={(item) => item.id}
           ListEmptyComponent={emptyList}
@@ -776,9 +776,7 @@ const DrawerRowItem = memo(function DrawerRowItem({
         <View style={styles.rowIconSlot}>
           <Icon name="folder" size={15} tintColor={theme.textSecondary} />
         </View>
-        <Text style={styles.projectTitle} numberOfLines={1}>
-          {item.title}
-        </Text>
+        <Text style={styles.projectTitle}>{item.title}</Text>
         <View style={styles.projectActions}>
           <Button
             accessibilityLabel={`Create new chat in ${item.title}`}
@@ -836,9 +834,7 @@ const DrawerRowItem = memo(function DrawerRowItem({
               )}
             </View>
             <View style={[styles.threadContent, pressed && styles.drawerPressedContent]}>
-              <Text style={styles.threadTitle} numberOfLines={1}>
-                {item.thread.title}
-              </Text>
+              <Text style={styles.threadTitle}>{item.thread.title}</Text>
               <Text style={styles.threadTime} numberOfLines={1}>
                 {formatRelativeTime(item.thread.lastActivityAt ?? item.thread.updatedAt)}
               </Text>
@@ -1088,7 +1084,7 @@ function WorkspaceBrowserModal({
               </Pressable>
               <View style={styles.workspaceLocation}>
                 <Text style={styles.workspaceLocationTitle} numberOfLines={1}>
-                  {projectName(currentBrowserPath)}
+                  {workspaceName(currentBrowserPath) ?? "codex-relay"}
                 </Text>
                 <Text style={styles.workspaceLocationPath} numberOfLines={1}>
                   {currentBrowserPath ?? "codex-relay"}
@@ -1133,7 +1129,7 @@ function WorkspaceBrowserModal({
               onPress={() => void onCreateThread(currentBrowserPath)}
               selected
               title="New Chat Here"
-              subtitle={projectName(currentBrowserPath)}
+              subtitle={workspaceName(currentBrowserPath) ?? "codex-relay"}
             />
           </View>
         </View>
@@ -1275,7 +1271,7 @@ function buildDrawerRows(
   >();
 
   for (const thread of threads) {
-    const title = projectName(thread.cwd);
+    const title = workspaceName(thread.cwd) ?? "codex-relay";
     const key = thread.cwd ?? title;
     const group = groups.get(key);
     if (group) {
@@ -1359,10 +1355,6 @@ function indexThreadsById(threads: ThreadSummary[]) {
   return threadsById;
 }
 
-function getEstimatedDrawerRowSize(row: DrawerRow) {
-  return row.kind === "thread" ? 44 : 32;
-}
-
 function getDrawerStatus(state: ThreadDrawerContentProps["state"]) {
   const drawerHistoryEntry = state.history.find(
     (entry): entry is { status: "closed" | "open"; type: "drawer" } => entry.type === "drawer",
@@ -1415,15 +1407,6 @@ function threadMatchesSearch(thread: ThreadSummary, normalizedQuery: string) {
 
 function normalizeSearchValue(value: string | undefined) {
   return (value ?? "").trim().toLocaleLowerCase();
-}
-
-function projectName(cwd: string | undefined) {
-  if (!cwd) {
-    return "codex-relay";
-  }
-
-  const parts = cwd.split("/").filter(Boolean);
-  return parts.at(-1) ?? cwd;
 }
 
 function formatRelativeTime(value: string) {
@@ -1617,11 +1600,13 @@ const styles = StyleSheet.create({
   projectHeader: {
     alignItems: "center",
     flexDirection: "row",
-    height: 32,
+    minHeight: 32,
     paddingRight: 2,
+    paddingVertical: 4,
   },
   projectTitle: {
     flex: 1,
+    flexShrink: 1,
     fontSize: 12,
     fontWeight: "500",
     lineHeight: 16,

--- a/apps/mobile/src/components/chat/workspace-preview/GitWorkspacePreviewTab.tsx
+++ b/apps/mobile/src/components/chat/workspace-preview/GitWorkspacePreviewTab.tsx
@@ -24,6 +24,7 @@ import { Icon } from "@/components/ui/icon";
 import { Text as UiText } from "@/components/ui/text";
 import { Colors, Fonts, Spacing } from "@/constants/theme";
 import { hapticSelection } from "@/lib/haptics";
+import { workspaceName } from "@/lib/workspace-name";
 
 import { HighlightedCodeBlock } from "../MessageBubble";
 
@@ -770,8 +771,7 @@ function errorMessage(error: unknown) {
 }
 
 function workspaceDisplayName(workspacePath: string) {
-  const parts = workspacePath.split("/").filter(Boolean);
-  return parts.at(-1) ?? workspacePath;
+  return workspaceName(workspacePath) ?? workspacePath;
 }
 
 const gitPreviewLayoutTransition = LinearTransition.duration(180);

--- a/apps/mobile/src/lib/workspace-name.test.ts
+++ b/apps/mobile/src/lib/workspace-name.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+
+import { workspaceName } from "./workspace-name";
+
+describe("workspaceName", () => {
+  it("returns the final directory from POSIX and Windows paths", () => {
+    expect(workspaceName("/Users/lea/projects/codex-relay")).toBe("codex-relay");
+    expect(workspaceName("C:\\Users\\lea\\projects\\codex-relay")).toBe("codex-relay");
+  });
+});

--- a/apps/mobile/src/lib/workspace-name.ts
+++ b/apps/mobile/src/lib/workspace-name.ts
@@ -1,0 +1,10 @@
+export function workspaceName(workspacePath: string | undefined) {
+  if (!workspacePath) {
+    return undefined;
+  }
+
+  return workspacePath
+    .split(/[\\/]+/)
+    .filter(Boolean)
+    .at(-1);
+}


### PR DESCRIPTION
## Summary

- show workspace directory names for Windows and POSIX paths
- let project and conversation titles wrap in the mobile drawer
- reuse the workspace label helper in the connection banner and Git preview

## Validation

- `node node_modules/vitest/vitest.mjs run apps/mobile/src/lib/workspace-name.test.ts`
- `tsc -p apps/mobile/tsconfig.json --noEmit`
- `oxlint apps packages --import-plugin --react-plugin --jsx-a11y-plugin --vitest-plugin`
- targeted `oxfmt --check`