### PR TITLE
fix: suppress subagent completion alerts

### DIFF
--- a/.changeset/quiet-subagents.md
+++ b/.changeset/quiet-subagents.md
@@ -1,0 +1,5 @@
+---
+"codex-relay": patch
+---
+
+Avoid turn-complete push notifications for spawned subagent threads.

--- a/packages/codex-relay/src/app.ts
+++ b/packages/codex-relay/src/app.ts
@@ -7264,14 +7264,18 @@ function observeAppServerPushNotifications(
   dispatcher: PushNotificationDispatcher,
 ) {
   const dispatchedEventIds = new Set<string>();
-  const dispatch = (event: PushNotificationEvent, eventId: string) => {
-    if (dispatchedEventIds.has(eventId)) {
-      return;
-    }
+  const subagentThreadIds = new Set<string>();
+  const rememberEventId = (eventId: string) => {
     if (dispatchedEventIds.size >= 1000) {
       dispatchedEventIds.clear();
     }
     dispatchedEventIds.add(eventId);
+  };
+  const dispatch = (event: PushNotificationEvent, eventId: string) => {
+    if (dispatchedEventIds.has(eventId)) {
+      return;
+    }
+    rememberEventId(eventId);
     void dispatcher.dispatch(event).catch((error) => {
       relayDebugLog("push_notification.dispatch_failed", {
         error: errorMessage(error),
@@ -7283,11 +7287,17 @@ function observeAppServerPushNotifications(
   };
 
   appServer.onNotification((notification) => {
+    rememberSubagentThreadIds(notification, subagentThreadIds);
     const event = pushNotificationEventFromTerminalNotification(notification);
     if (!event) {
       return;
     }
-    dispatch(event, `${event.intent}:${event.threadId}:${event.turnId ?? ""}`);
+    const eventId = `${event.intent}:${event.threadId}:${event.turnId ?? ""}`;
+    if (subagentThreadIds.delete(event.threadId)) {
+      rememberEventId(eventId);
+      return;
+    }
+    dispatch(event, eventId);
   });
 
   appServer.onRequest((request) => {
@@ -7297,6 +7307,23 @@ function observeAppServerPushNotifications(
     }
     dispatch(event, `${event.intent}:${event.threadId}:${event.turnId ?? ""}:${request.id}`);
   });
+}
+
+function rememberSubagentThreadIds(
+  notification: AppServerNotification,
+  subagentThreadIds: Set<string>,
+) {
+  const item = objectRecord(recordParams(notification)?.item);
+  if (
+    item?.type !== "collabAgentToolCall" ||
+    !["spawnAgent", "sendInput", "resumeAgent"].includes(String(item.tool))
+  ) {
+    return;
+  }
+
+  for (const threadId of stringArray(item.receiverThreadIds)) {
+    subagentThreadIds.add(threadId);
+  }
 }
 
 function pushNotificationEventFromTerminalNotification(notification: AppServerNotification) {

--- a/packages/codex-relay/test/app.test.ts
+++ b/packages/codex-relay/test/app.test.ts
@@ -1276,6 +1276,10 @@ describe("Codex Relay server routes", () => {
       });
       handler({
         method: "turn/completed",
+        params: { status: "completed", threadId: "agent-thread-1", turnId: "agent-turn-1" },
+      });
+      handler({
+        method: "turn/completed",
         params: { status: "completed", threadId: "thread-1", turnId: "turn-1" },
       });
       handler({

--- a/packages/codex-relay/test/app.test.ts
+++ b/packages/codex-relay/test/app.test.ts
@@ -1252,6 +1252,29 @@ describe("Codex Relay server routes", () => {
 
     for (const handler of notificationHandlers) {
       handler({
+        method: "item/completed",
+        params: {
+          item: {
+            agentsStates: {},
+            id: "spawn-agent",
+            model: null,
+            prompt: null,
+            reasoningEffort: null,
+            receiverThreadIds: ["agent-thread-1"],
+            senderThreadId: "thread-1",
+            status: "completed",
+            tool: "spawnAgent",
+            type: "collabAgentToolCall",
+          },
+          threadId: "thread-1",
+          turnId: "turn-1",
+        },
+      });
+      handler({
+        method: "turn/completed",
+        params: { status: "completed", threadId: "agent-thread-1", turnId: "agent-turn-1" },
+      });
+      handler({
         method: "turn/completed",
         params: { status: "completed", threadId: "thread-1", turnId: "turn-1" },
       });


### PR DESCRIPTION
## Summary

- suppress turn-complete push notifications for spawned subagent threads
- continue notifying when the parent chat completes
- deduplicate repeated terminal events for suppressed agent threads

## Validation

- `node node_modules/vitest/vitest.mjs run packages/codex-relay/test/app.test.ts -t "observes app-server terminal turns and action requests without handling the request"`
- `tsc -p packages/codex-relay/tsconfig.json --noEmit`
- targeted `oxlint` and `oxfmt --check`
- `tsdown` package build