### PR TITLE
fix: deliver queued input after turn completion

### DIFF
--- a/.changeset/queued-input-completion.md
+++ b/.changeset/queued-input-completion.md
@@ -1,0 +1,5 @@
+---
+"codex-relay": patch
+---
+
+Start queued input when the active turn completes during queued-input submission.

--- a/packages/codex-relay/src/app.ts
+++ b/packages/codex-relay/src/app.ts
@@ -325,6 +325,7 @@ export function createApp(options: AppOptions = {}) {
   const pendingApprovals = new Map<string, PendingApproval>();
   const resolvedApprovals = new Map<string, ResolvedApproval>();
   const queuedInputsByThreadId = new Map<string, QueuedThreadInput[]>();
+  const threadOperationTails = new Map<string, Promise<void>>();
   const workspaceTerminalSessions = new Map<string, WorkspaceTerminalSession>();
   const activeAppServerTurnIdsByThreadId = new Map<string, string>();
   const appServerHistoryLoadsByThreadId = new Map<string, Promise<void>>();
@@ -332,6 +333,21 @@ export function createApp(options: AppOptions = {}) {
   const secureSessionsByTokenHash = new Map<string, SecureSession>();
   const activeStreamControllers = new Set<ReadableStreamDefaultController<Uint8Array>>();
   const threadOptions = { workingDirectory: workspacePath };
+  function runThreadOperation<T>(threadId: string, operation: () => Promise<T>) {
+    const previous = threadOperationTails.get(threadId) ?? Promise.resolve();
+    const result = previous.then(operation, operation);
+    const tail = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    threadOperationTails.set(threadId, tail);
+    void tail.finally(() => {
+      if (threadOperationTails.get(threadId) === tail) {
+        threadOperationTails.delete(threadId);
+      }
+    });
+    return result;
+  }
   const pushNotificationDispatcher = options.pairing
     ? createPushNotificationDispatcher({
         sender: options.pushNotificationSender ?? createExpoPushNotificationSender(),
@@ -2332,87 +2348,89 @@ export function createApp(options: AppOptions = {}) {
 
   app.post("/v1/threads/:threadId/input", async (c) => {
     const threadId = c.req.param("threadId");
-    const knownThread = await ensureKnownThread({
-      appServer,
-      threadId,
-      messagesByThreadId,
-      threads,
-    });
-    if (!knownThread) {
-      return secureJson(
-        c,
-        options.pairing,
-        secureSessionsByTokenHash,
-        apiError("not_found", `Thread ${threadId} is not known to this server.`),
-        404,
-      );
-    }
-    if (!appServer) {
-      return secureJson(
-        c,
-        options.pairing,
-        secureSessionsByTokenHash,
-        apiError("unsupported", "Running-thread input requires the Codex app-server."),
-        409,
-      );
-    }
-    if (knownThread.state !== "running") {
-      return secureJson(
-        c,
-        options.pairing,
-        secureSessionsByTokenHash,
-        apiError("thread_not_running", `Thread ${threadId} is not currently running.`),
-        409,
-      );
-    }
+    return runThreadOperation(threadId, async () => {
+      const knownThread = await ensureKnownThread({
+        appServer,
+        threadId,
+        messagesByThreadId,
+        threads,
+      });
+      if (!knownThread) {
+        return secureJson(
+          c,
+          options.pairing,
+          secureSessionsByTokenHash,
+          apiError("not_found", `Thread ${threadId} is not known to this server.`),
+          404,
+        );
+      }
+      if (!appServer) {
+        return secureJson(
+          c,
+          options.pairing,
+          secureSessionsByTokenHash,
+          apiError("unsupported", "Running-thread input requires the Codex app-server."),
+          409,
+        );
+      }
+      if (knownThread.state !== "running") {
+        return secureJson(
+          c,
+          options.pairing,
+          secureSessionsByTokenHash,
+          apiError("thread_not_running", `Thread ${threadId} is not currently running.`),
+          409,
+        );
+      }
 
-    const parsed = await parseRequestJson(
-      c,
-      options.pairing,
-      secureSessionsByTokenHash,
-      RunThreadRequestSchema,
-    );
-    if (!parsed.success) {
-      return secureJson(
+      const parsed = await parseRequestJson(
         c,
         options.pairing,
         secureSessionsByTokenHash,
-        validationError(parsed.error),
-        400,
+        RunThreadRequestSchema,
       );
-    }
+      if (!parsed.success) {
+        return secureJson(
+          c,
+          options.pairing,
+          secureSessionsByTokenHash,
+          validationError(parsed.error),
+          400,
+        );
+      }
 
-    const runOptions = withRuntimePreferences(
-      await preferences.read(knownThread.cwd ?? workspacePath),
-      parsed.data,
-    );
-    const skills = runOptions.skills ?? [];
-    const prompt = runOptions.prompt;
-    const queuedInputs = queuedInputsByThreadId.get(threadId) ?? [];
-    const queuedInput: QueuedThreadInput = {
-      attachments: runOptions.attachments ?? [],
-      id: randomUUID(),
-      prompt,
-      runOptions,
-      skills,
-      workspacePath: knownThread.cwd ?? workspacePath,
-    };
-    queuedInputs.push(queuedInput);
-    queuedInputsByThreadId.set(threadId, queuedInputs);
+      const runOptions = withRuntimePreferences(
+        await preferences.read(knownThread.cwd ?? workspacePath),
+        parsed.data,
+      );
+      const skills = runOptions.skills ?? [];
+      const prompt = runOptions.prompt;
+      const queuedInputs = queuedInputsByThreadId.get(threadId) ?? [];
+      const queuedInput: QueuedThreadInput = {
+        attachments: runOptions.attachments ?? [],
+        id: randomUUID(),
+        prompt,
+        runOptions,
+        skills,
+        workspacePath: knownThread.cwd ?? workspacePath,
+      };
+      queuedInputs.push(queuedInput);
+      queuedInputsByThreadId.set(threadId, queuedInputs);
 
-    const thread = updateThread(threads, messagesByThreadId, threadId, {
-      state: "running",
-      lastPrompt: promptWithAttachmentReferences(prompt, runOptions.attachments ?? []),
-      lastError: undefined,
-      ...runtimeMetadataFromOptions(runOptions),
+      const thread = updateThread(threads, messagesByThreadId, threadId, {
+        state: "running",
+        lastPrompt: promptWithAttachmentReferences(prompt, runOptions.attachments ?? []),
+        lastError: undefined,
+        ...runtimeMetadataFromOptions(runOptions),
+      });
+      const response: SubmitThreadInputResponse = SubmitThreadInputResponseSchema.parse({
+        acceptedAs: "queued",
+        input: queuedThreadInputSummary(queuedInput),
+        queueLength: queuedInputsByThreadId.get(threadId)?.length ?? 0,
+        thread,
+      });
+      return secureJson(c, options.pairing, secureSessionsByTokenHash, response, 202);
     });
-    const response: SubmitThreadInputResponse = SubmitThreadInputResponseSchema.parse({
-      acceptedAs: "queued",
-      input: queuedThreadInputSummary(queuedInput),
-      queueLength: queuedInputsByThreadId.get(threadId)?.length ?? 0,
-      thread,
-    });
-    return secureJson(c, options.pairing, secureSessionsByTokenHash, response, 202);
   });
 
   app.delete("/v1/threads/:threadId/input/:inputId", async (c) => {
@@ -2734,6 +2752,7 @@ export function createApp(options: AppOptions = {}) {
           messagesByThreadId,
           pendingApprovals,
           queuedInputsByThreadId,
+          runThreadOperation,
           prompt,
           attachments: runOptions.attachments ?? [],
           secureSession,
@@ -3044,6 +3063,7 @@ async function runPromptStreamed(input: {
   messagesByThreadId: Map<string, ChatMessage[]>;
   pendingApprovals: Map<string, PendingApproval>;
   queuedInputsByThreadId: Map<string, QueuedThreadInput[]>;
+  runThreadOperation: <T>(threadId: string, operation: () => Promise<T>) => Promise<T>;
   prompt: string;
   secureSession?: SecureSessionHandle;
   steeringThreads: Set<string>;
@@ -3071,6 +3091,7 @@ async function runPromptStreamed(input: {
       messagesByThreadId: input.messagesByThreadId,
       pendingApprovals: input.pendingApprovals,
       queuedInputsByThreadId: input.queuedInputsByThreadId,
+      runThreadOperation: input.runThreadOperation,
       prompt: input.prompt,
       runOptions: input.runOptions,
       secureSession: input.secureSession,
@@ -3766,6 +3787,7 @@ async function runAppServerPromptStreamed(input: {
   messagesByThreadId: Map<string, ChatMessage[]>;
   pendingApprovals: Map<string, PendingApproval>;
   queuedInputsByThreadId: Map<string, QueuedThreadInput[]>;
+  runThreadOperation: <T>(threadId: string, operation: () => Promise<T>) => Promise<T>;
   prompt: string;
   runOptions: {
     model?: string;
@@ -4243,12 +4265,19 @@ async function runAppServerPromptStreamed(input: {
             const state = terminalTurnState(notification.method, params);
             const terminalTurnId =
               firstString(params, ["turnId"]) ?? turnIdFromParams(params) ?? activeTurnId;
-            finishTerminalTurn({
-              lastError: state === "failed" ? turnErrorMessage(params) : undefined,
-              method: notification.method,
-              state,
-              turnId: terminalTurnId,
-            });
+            void input
+              .runThreadOperation(activeThreadId, async () => {
+                finishTerminalTurn({
+                  lastError: state === "failed" ? turnErrorMessage(params) : undefined,
+                  method: notification.method,
+                  state,
+                  turnId: terminalTurnId,
+                });
+              })
+              .catch((error: unknown) => {
+                cleanupNotificationHandler();
+                rejectCompleted(error);
+              });
             return;
           }
         }

--- a/packages/codex-relay/test/app.test.ts
+++ b/packages/codex-relay/test/app.test.ts
@@ -14,7 +14,10 @@ import { describe, expect, it, vi } from "vitest";
 import { createApp } from "../src/app.js";
 import type { CodexClient, CodexThread } from "../src/codex.js";
 import { createTursoPairingSessionStore } from "../src/pairing-store.js";
-import { createFileRuntimePreferencesStore } from "../src/preferences-store.js";
+import {
+  createFileRuntimePreferencesStore,
+  type RuntimePreferencesStore,
+} from "../src/preferences-store.js";
 import type { PushNotificationSender, RelayPushNotification } from "../src/push-notifications.js";
 import { createServerIdentity } from "../src/secure-transport.js";
 
@@ -5336,6 +5339,121 @@ describe("Codex Relay server routes", () => {
     expect(body).not.toContain("thread.error");
     expect(body).toContain("recovered reply");
     expect(body).toContain('"id":"app-thread-stale"');
+  });
+
+  it("hands off queued input when the active turn completes during input submission", async () => {
+    const workspacePath = await mkdtemp(join(tmpdir(), "codex-relay-workspace-"));
+    const notificationHandlers = new Set<(notification: unknown) => void>();
+    let delayQueuedPreferenceRead = false;
+    let releaseQueuedPreferenceRead: (() => void) | undefined;
+    const queuedPreferenceRead = new Promise<void>((resolve) => {
+      releaseQueuedPreferenceRead = resolve;
+    });
+    let signalQueuedPreferenceRead: (() => void) | undefined;
+    const queuedPreferenceReadStarted = new Promise<void>((resolve) => {
+      signalQueuedPreferenceRead = resolve;
+    });
+    const preferences: RuntimePreferencesStore = {
+      async read() {
+        if (delayQueuedPreferenceRead) {
+          signalQueuedPreferenceRead?.();
+          await queuedPreferenceRead;
+        }
+        return { runtimeMode: "default" };
+      },
+      async readByWorkspacePath() {
+        return {};
+      },
+      async update() {
+        return { runtimeMode: "default" };
+      },
+    };
+    const now = Date.now() / 1000;
+    let turnCount = 0;
+    const startTurn = vi.fn<(params: unknown) => Promise<unknown>>(async () => {
+      turnCount += 1;
+      return {
+        id: `turn-queue-race-${turnCount}`,
+        items: [],
+        status: "running",
+        startedAt: null,
+        completedAt: null,
+      };
+    });
+    const appServer = {
+      onNotification(handler: (notification: unknown) => void) {
+        notificationHandlers.add(handler);
+        return () => notificationHandlers.delete(handler);
+      },
+      onRequest() {
+        return () => undefined;
+      },
+      startThread: vi.fn<() => Promise<unknown>>(async () => ({
+        id: "app-thread-queue-race",
+        createdAt: now,
+        cwd: workspacePath,
+        modelProvider: "gpt-5.5",
+        name: "Queue race",
+        preview: "Queue race",
+        source: "app",
+        status: "idle",
+        turns: [],
+        updatedAt: now,
+      })),
+      startTurn,
+    };
+    const app = createApp({
+      appServer: appServer as never,
+      codex: createMockCodex(),
+      preferences,
+      workspacePath,
+    });
+
+    await app.request("/v1/threads", {
+      method: "POST",
+      body: JSON.stringify({ title: "Queue race" }),
+      headers: { "content-type": "application/json" },
+    });
+    const streamResponse = await app.request("/v1/threads/app-thread-queue-race/runs/stream", {
+      method: "POST",
+      body: JSON.stringify({ prompt: "Initial run" }),
+      headers: { "content-type": "application/json" },
+    });
+    await waitUntil(() => expect(startTurn).toHaveBeenCalledTimes(1));
+
+    delayQueuedPreferenceRead = true;
+    const queuedResponse = app.request("/v1/threads/app-thread-queue-race/input", {
+      method: "POST",
+      body: JSON.stringify({ prompt: "Queued after completion" }),
+      headers: { "content-type": "application/json" },
+    });
+    await queuedPreferenceReadStarted;
+    for (const handler of notificationHandlers) {
+      handler({
+        method: "turn/completed",
+        params: {
+          status: "completed",
+          threadId: "app-thread-queue-race",
+          turnId: "turn-queue-race-1",
+        },
+      });
+    }
+    releaseQueuedPreferenceRead?.();
+
+    await expect(queuedResponse).resolves.toHaveProperty("status", 202);
+    await waitUntil(() => expect(startTurn).toHaveBeenCalledTimes(2));
+
+    for (const handler of notificationHandlers) {
+      handler({
+        method: "turn/completed",
+        params: {
+          status: "completed",
+          threadId: "app-thread-queue-race",
+          turnId: "turn-queue-race-2",
+        },
+      });
+    }
+    expect(await streamResponse.text()).toContain("thread.state.changed");
   });
 
   it("queues additional running-thread input on the server", async () => {


### PR DESCRIPTION
Closes #27

## Summary

- serialize queued-input submission with terminal handling for the same thread
- prevent a completed turn from overtaking an in-flight queued input
- add a regression test for the completion/submission race

## Validation

- `node node_modules/vitest/vitest.mjs run packages/codex-relay/test/app.test.ts -t "queued"`
- `node node_modules/typescript/bin/tsc -p packages/codex-relay/tsconfig.json --noEmit`
- `oxlint packages/codex-relay/src/app.ts packages/codex-relay/test/app.test.ts --import-plugin --react-plugin --jsx-a11y-plugin --vitest-plugin`
- `pnpm exec oxfmt packages/codex-relay/src/app.ts packages/codex-relay/test/app.test.ts --check`
- `pnpm --filter codex-relay build`