### PR TITLE
fix: add chat refresh action to header

### DIFF
--- a/.changeset/chat-header-refresh.md
+++ b/.changeset/chat-header-refresh.md
@@ -1,0 +1,5 @@
+---
+"@codex-relay/mobile": patch
+---
+
+Replace the duplicate chat-header new-chat action with a refresh action. New chats remain available from the workspace sidebar.

--- a/apps/mobile/src/components/chat/ChatScreen.tsx
+++ b/apps/mobile/src/components/chat/ChatScreen.tsx
@@ -1911,31 +1911,6 @@ export function ChatScreen({ initialPairingUrl }: ChatScreenProps = {}) {
     hapticWarning();
   }
 
-  async function createNewThread() {
-    if (isRunning) {
-      return;
-    }
-
-    const newThreadCollaborationMode = collaborationMode;
-    try {
-      const response = await createThreadMutation.mutateAsync({
-        title: "New chat",
-        collaborationMode: newThreadCollaborationMode,
-        workspacePath: activeWorkspacePath,
-      });
-      setThreadCollaborationMode(response.thread.id, newThreadCollaborationMode);
-      setThreadDetailState(queryClient, response.thread, response.messages);
-      setActiveThread(response.thread.id);
-      clearQueuedPrompts();
-      setQueuedInputsState(queryClient, response.thread.id, []);
-      setConnection("connected");
-      hapticSuccess();
-    } catch (caught) {
-      syncPairedSessionState();
-      setConnection("offline", errorMessage(caught));
-    }
-  }
-
   function currentRuntimePreferences(): RuntimePreferences {
     const thread = activeThread;
     const targetWorkspacePath = thread?.cwd ?? workspacePath;
@@ -2155,10 +2130,9 @@ export function ChatScreen({ initialPairingUrl }: ChatScreenProps = {}) {
   const chatTrailingActions: ChatShellAction[] = hasPairedSession
     ? [
         {
-          disabled: isRunning,
-          icon: "newThread",
-          label: "New thread",
-          onPress: createNewThread,
+          icon: "refresh",
+          label: "Refresh chat",
+          onPress: refresh,
         },
         {
           icon: usesWideLayout ? (isWidePreviewVisible ? "previewHide" : "preview") : "preview",


### PR DESCRIPTION
Closes #14

## Summary

- replace the duplicate header **New thread** button with **Refresh chat**
- refresh the relay status, thread list, and active conversation from the header
- keep new-chat creation in the workspace sidebar, where it remains available per project

This removes a disabled, duplicate action from the compact header while retaining new-chat functionality in the more useful workspace-specific location.

## Validation

- `pnpm --filter @codex-relay/mobile typecheck`
- `oxlint apps/mobile/src/components/chat/ChatScreen.tsx --import-plugin --react-plugin --jsx-a11y-plugin --vitest-plugin`
- `pnpm exec oxfmt apps/mobile/src/components/chat/ChatScreen.tsx .changeset/chat-header-refresh.md --check`