### PR TITLE
fix: stop abandoned preview checks after clients disconnect

### DIFF
--- a/.changeset/quiet-streams-rest.md
+++ b/.changeset/quiet-streams-rest.md
@@ -1,0 +1,5 @@
+---
+"codex-relay": patch
+---
+
+fix: clean up cancelled thread streams and stop repeated web preview probes

--- a/packages/codex-relay/src/app.ts
+++ b/packages/codex-relay/src/app.ts
@@ -330,7 +330,10 @@ export function createApp(options: AppOptions = {}) {
   const appServerHistoryLoadsByThreadId = new Map<string, Promise<void>>();
   const steeringThreads = new Set<string>();
   const secureSessionsByTokenHash = new Map<string, SecureSession>();
-  const activeStreamControllers = new Set<ReadableStreamDefaultController<Uint8Array>>();
+  const activeStreamControllers = new Map<
+    ReadableStreamDefaultController<Uint8Array>,
+    () => void
+  >();
   const threadOptions = { workingDirectory: workspacePath };
   const pushNotificationDispatcher = options.pairing
     ? createPushNotificationDispatcher({
@@ -1180,7 +1183,7 @@ export function createApp(options: AppOptions = {}) {
     const stream = new ReadableStream<Uint8Array>({
       start(controller) {
         streamController = controller;
-        activeStreamControllers.add(controller);
+        activeStreamControllers.set(controller, closeStream);
         send(workspaceTerminalOutputResponse(session, since));
         if (session.exitedAt) {
           return;
@@ -2667,20 +2670,32 @@ export function createApp(options: AppOptions = {}) {
     });
     const encoder = new TextEncoder();
     const secureSession = getSecureSessionForRequest(c, options.pairing, secureSessionsByTokenHash);
-    let streamController: ReadableStreamDefaultController<Uint8Array> | undefined;
     let streamSettled = false;
+    let closeStream = () => {};
     const stream = new ReadableStream<Uint8Array>({
       start(controller) {
-        streamController = controller;
-        activeStreamControllers.add(controller);
+        const attachmentAbortController = new AbortController();
+        let closed = false;
+        let stopPreviewMonitor = () => {};
+        closeStream = () => {
+          if (closed) {
+            return;
+          }
+          closed = true;
+          stopPreviewMonitor();
+          attachmentAbortController.abort();
+          activeStreamControllers.delete(controller);
+          closeSseController(controller);
+        };
+        activeStreamControllers.set(controller, closeStream);
         relayDebugLog("thread.stream.started", {
           mode: !runOptions.prompt && appServer ? "attach" : "run",
           threadId,
         });
-        const stopPreviewMonitor = startWebPreviewTargetMonitor({
+        stopPreviewMonitor = startWebPreviewTargetMonitor({
           bridgeUrl: c.req.url,
           send(target) {
-            sendSse(controller, encoder, secureSession, {
+            return sendSse(controller, encoder, secureSession, {
               type: "thread.preview_target.detected",
               threadId,
               target,
@@ -2695,13 +2710,13 @@ export function createApp(options: AppOptions = {}) {
             messagesByThreadId,
             pendingApprovals,
             secureSession,
+            signal: attachmentAbortController.signal,
             threadId,
             threads,
           }).finally(() => {
             streamSettled = true;
             relayDebugLog("thread.stream.finished", { mode: "attach", threadId });
-            activeStreamControllers.delete(controller);
-            stopPreviewMonitor();
+            closeStream();
           });
           return;
         }
@@ -2715,11 +2730,9 @@ export function createApp(options: AppOptions = {}) {
               "Running-thread stream attachment requires the Codex app-server.",
             ).error,
           });
-          closeSseController(controller);
           streamSettled = true;
           relayDebugLog("thread.stream.finished", { mode: "unsupported", threadId });
-          activeStreamControllers.delete(controller);
-          stopPreviewMonitor();
+          closeStream();
           return;
         }
         const skills = runOptions.skills ?? [];
@@ -2746,14 +2759,11 @@ export function createApp(options: AppOptions = {}) {
         }).finally(() => {
           streamSettled = true;
           relayDebugLog("thread.stream.finished", { mode: "run", threadId });
-          activeStreamControllers.delete(controller);
-          stopPreviewMonitor();
+          closeStream();
         });
       },
       cancel(reason) {
-        if (streamController) {
-          activeStreamControllers.delete(streamController);
-        }
+        closeStream();
         relayDebugLog("thread.stream.cancelled_by_client", {
           reason: debugReason(reason),
           settled: streamSettled,
@@ -3278,8 +3288,6 @@ async function runPromptStreamed(input: {
       thread: threadSummary,
       error: errorBody.error,
     });
-  } finally {
-    closeSseController(input.controller);
   }
 }
 
@@ -3423,6 +3431,7 @@ async function streamRunningAppServerThread(input: {
   messagesByThreadId: Map<string, ChatMessage[]>;
   pendingApprovals: Map<string, PendingApproval>;
   secureSession?: SecureSessionHandle;
+  signal: AbortSignal;
   threadId: string;
   threads: Map<string, ThreadMetadata>;
 }) {
@@ -3432,8 +3441,20 @@ async function streamRunningAppServerThread(input: {
   let observedTurnActivity = false;
   let producedTurnOutput = false;
   let threadSummary = input.threads.get(input.threadId);
+  let cleanupNotificationHandler = (): void => undefined;
+  let cleanupRequestHandler = (): void => undefined;
+  let handlersCleaned = false;
 
-  const cleanupRequestHandler = input.appServer.onRequest((request) => {
+  const cleanupHandlers = () => {
+    if (handlersCleaned) {
+      return;
+    }
+    handlersCleaned = true;
+    cleanupRequestHandler();
+    cleanupNotificationHandler();
+  };
+
+  cleanupRequestHandler = input.appServer.onRequest((request) => {
     if (!isApprovalServerRequest(request.method)) {
       void input.appServer.rejectRequest(
         request.id,
@@ -3499,8 +3520,20 @@ async function streamRunningAppServerThread(input: {
     });
   });
 
-  let cleanupNotificationHandler = (): void => undefined;
   const completed = new Promise<void>((resolve, reject) => {
+    let settled = false;
+    const finish = (error?: unknown) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      cleanupHandlers();
+      if (error === undefined) {
+        resolve();
+      } else {
+        reject(error);
+      }
+    };
     cleanupNotificationHandler = input.appServer.onNotification((notification) => {
       const params = recordParams(notification);
       const notificationThreadId = firstString(params, ["threadId"]);
@@ -3523,8 +3556,7 @@ async function streamRunningAppServerThread(input: {
               thread: threadSummary,
             });
             if (state !== "running") {
-              cleanupNotificationHandler();
-              resolve();
+              finish();
             }
             return;
           }
@@ -3668,8 +3700,7 @@ async function streamRunningAppServerThread(input: {
                 threadId: input.threadId,
                 threads: input.threads,
               });
-              cleanupNotificationHandler();
-              resolve();
+              finish();
               return;
             }
             if (assistantMessageId) {
@@ -3715,22 +3746,37 @@ async function streamRunningAppServerThread(input: {
                 error: errorBody.error,
               });
             }
-            cleanupNotificationHandler();
-            resolve();
+            finish();
             return;
           }
         }
       } catch (error) {
-        cleanupNotificationHandler();
-        reject(error);
+        finish(error);
       }
     });
   });
+  let removeAbortListener = () => {};
+  const aborted = new Promise<void>((resolve) => {
+    const onAbort = () => {
+      cleanupHandlers();
+      resolve();
+    };
+    if (input.signal.aborted) {
+      onAbort();
+      return;
+    }
+    input.signal.addEventListener("abort", onAbort, { once: true });
+    removeAbortListener = () => input.signal.removeEventListener("abort", onAbort);
+  });
 
   try {
-    const appServerThread = await input.appServer.readThread(input.threadId, {
-      includeTurns: false,
-    });
+    const appServerThread = await Promise.race([
+      input.appServer.readThread(input.threadId, { includeTurns: false }),
+      aborted.then(() => undefined),
+    ]);
+    if (!appServerThread || input.signal.aborted) {
+      return;
+    }
     threadSummary = rememberAppServerThread(input.threads, appServerThread);
     sendSse(input.controller, input.encoder, input.secureSession, {
       type: "thread.state.changed",
@@ -3739,8 +3785,11 @@ async function streamRunningAppServerThread(input: {
     if (threadSummary.state !== "running") {
       return;
     }
-    await completed;
+    await Promise.race([completed, aborted]);
   } catch (error) {
+    if (input.signal.aborted) {
+      return;
+    }
     threadSummary = updateThread(input.threads, input.messagesByThreadId, input.threadId, {
       state: "failed",
       lastError: errorMessage(error),
@@ -3751,9 +3800,8 @@ async function streamRunningAppServerThread(input: {
       error: apiError("codex_run_failed", threadSummary.lastError ?? "Codex run failed.").error,
     });
   } finally {
-    cleanupRequestHandler();
-    cleanupNotificationHandler();
-    closeSseController(input.controller);
+    removeAbortListener();
+    cleanupHandlers();
   }
 }
 
@@ -4398,7 +4446,6 @@ async function runAppServerPromptStreamed(input: {
       input.activeAppServerTurnIdsByThreadId.delete(activeThreadId);
       input.steeringThreads.delete(activeThreadId);
     }
-    closeSseController(input.controller);
   }
 }
 
@@ -5382,7 +5429,7 @@ function sendSse(
   encoder: TextEncoder,
   secureSession: SecureSessionHandle | undefined,
   event: StreamThreadRunEvent,
-) {
+): boolean {
   const parsed = StreamThreadRunEventSchema.parse(event);
   const threadId = threadIdFromStreamEvent(parsed);
   relayDebugLog("thread.stream.sse", {
@@ -5403,7 +5450,7 @@ function sendSse(
       stage: "event",
       threadId,
     });
-    return;
+    return false;
   }
   if (!enqueueSseChunk(controller, encoder.encode(`data: ${JSON.stringify(data)}\n\n`))) {
     relayDebugLog("thread.stream.sse.enqueue_failed", {
@@ -5411,7 +5458,9 @@ function sendSse(
       stage: "data",
       threadId,
     });
+    return false;
   }
+  return true;
 }
 
 function sendTerminalOutputSse(
@@ -5471,10 +5520,10 @@ function closeSseController(controller: ReadableStreamDefaultController<Uint8Arr
 }
 
 function closeActiveStreamControllers(
-  controllers: Set<ReadableStreamDefaultController<Uint8Array>>,
+  controllers: Map<ReadableStreamDefaultController<Uint8Array>, () => void>,
 ) {
-  for (const controller of controllers) {
-    closeSseController(controller);
+  for (const closeStream of controllers.values()) {
+    closeStream();
   }
   controllers.clear();
 }
@@ -5492,40 +5541,52 @@ function startWebPreviewTargetMonitor({
   send,
 }: {
   bridgeUrl: string;
-  send: (target: WebPreviewTarget) => void;
+  send: (target: WebPreviewTarget) => boolean;
 }) {
   const urls = webPreviewCandidateUrls(bridgeUrl);
-  const seenUrls = new Set<string>();
+  const abortController = new AbortController();
   let stopped = false;
+  let nextScan: ReturnType<typeof setTimeout> | undefined;
+
+  const stop = () => {
+    if (stopped) {
+      return;
+    }
+    stopped = true;
+    abortController.abort();
+    if (nextScan) {
+      clearTimeout(nextScan);
+      nextScan = undefined;
+    }
+  };
 
   async function scan() {
     if (stopped) {
       return;
     }
 
-    const targets = await detectWebPreviewTargets(urls);
-    for (const target of targets) {
-      if (stopped || seenUrls.has(target.url)) {
-        continue;
-      }
-
-      seenUrls.add(target.url);
+    const target = await detectWebPreviewTarget(urls, abortController.signal);
+    if (stopped) {
+      return;
+    }
+    if (target) {
+      stop();
       try {
         send(target);
       } catch {
-        stopped = true;
-        return;
+        // The stream may have closed between detection and delivery.
       }
+      return;
     }
+
+    nextScan = setTimeout(() => {
+      nextScan = undefined;
+      void scan();
+    }, 1500);
   }
 
   void scan();
-  const interval = setInterval(() => void scan(), 1500);
-
-  return () => {
-    stopped = true;
-    clearInterval(interval);
-  };
+  return stop;
 }
 
 function webPreviewCandidateUrls(bridgeUrl: string) {
@@ -5562,13 +5623,22 @@ function readCollaborationModeTemplate(name: (typeof collaborationModeTemplateNa
     .trim();
 }
 
-async function detectWebPreviewTargets(urls: string[]) {
-  const targets = await Promise.all(urls.map((url) => probeWebPreviewTarget(url)));
-  return targets.filter((target): target is WebPreviewTarget => Boolean(target));
+async function detectWebPreviewTarget(urls: string[], signal: AbortSignal) {
+  const targets = await Promise.all(urls.map((url) => probeWebPreviewTarget(url, signal)));
+  return targets.find((target): target is WebPreviewTarget => Boolean(target));
 }
 
-async function probeWebPreviewTarget(url: string): Promise<WebPreviewTarget | undefined> {
+async function probeWebPreviewTarget(
+  url: string,
+  signal: AbortSignal,
+): Promise<WebPreviewTarget | undefined> {
   const controller = new AbortController();
+  const abort = () => controller.abort();
+  if (signal.aborted) {
+    abort();
+  } else {
+    signal.addEventListener("abort", abort, { once: true });
+  }
   const timeout = setTimeout(() => controller.abort(), 700);
 
   try {
@@ -5596,6 +5666,7 @@ async function probeWebPreviewTarget(url: string): Promise<WebPreviewTarget | un
     return undefined;
   } finally {
     clearTimeout(timeout);
+    signal.removeEventListener("abort", abort);
   }
 }
 

--- a/packages/codex-relay/test/app.test.ts
+++ b/packages/codex-relay/test/app.test.ts
@@ -1896,6 +1896,9 @@ describe("Codex Relay server routes", () => {
   it("attaches to an already-running empty app-server thread", async () => {
     const workspacePath = await mkdtemp(join(tmpdir(), "codex-relay-workspace-"));
     const notificationHandlers = new Set<(notification: unknown) => void>();
+    const requestHandlers = new Set<(request: unknown) => void>();
+    const cleanupNotificationHandler = vi.fn<() => void>();
+    const cleanupRequestHandler = vi.fn<() => void>();
     const now = Date.now() / 1000;
     const appThread = {
       id: "app-thread-empty-stream",
@@ -1912,10 +1915,17 @@ describe("Codex Relay server routes", () => {
     const appServer = {
       onNotification(handler: (notification: unknown) => void) {
         notificationHandlers.add(handler);
-        return () => notificationHandlers.delete(handler);
+        return () => {
+          cleanupNotificationHandler();
+          notificationHandlers.delete(handler);
+        };
       },
-      onRequest() {
-        return () => undefined;
+      onRequest(handler: (request: unknown) => void) {
+        requestHandlers.add(handler);
+        return () => {
+          cleanupRequestHandler();
+          requestHandlers.delete(handler);
+        };
       },
       readThread: vi.fn<() => Promise<unknown>>(async () => {
         queueMicrotask(() => {
@@ -1946,6 +1956,190 @@ describe("Codex Relay server routes", () => {
     expect(appServer.readThread).toHaveBeenCalled();
     expect(body).toContain('"state":"running"');
     expect(body).toContain('"state":"idle"');
+    expect(notificationHandlers).toHaveLength(0);
+    expect(requestHandlers).toHaveLength(0);
+    expect(cleanupNotificationHandler).toHaveBeenCalledTimes(1);
+    expect(cleanupRequestHandler).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not accumulate preview probes or app-server handlers across cancelled attachments", async () => {
+    vi.useFakeTimers();
+    const previousPreviewPorts = process.env.CODEX_RELAY_WEB_PREVIEW_PORTS;
+    process.env.CODEX_RELAY_WEB_PREVIEW_PORTS = "65534";
+    const probeSignals: AbortSignal[] = [];
+    const fetchPreview = vi.fn<typeof fetch>(async (_input, init) => {
+      const signal = init?.signal;
+      if (!(signal instanceof AbortSignal)) {
+        throw new Error("Expected preview probe to include an AbortSignal.");
+      }
+      probeSignals.push(signal);
+      return new Promise<Response>((_resolve, reject) => {
+        signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+      });
+    });
+    vi.stubGlobal("fetch", fetchPreview);
+
+    const workspacePath = await mkdtemp(join(tmpdir(), "codex-relay-workspace-"));
+    const notificationHandlers = new Set<(notification: unknown) => void>();
+    const requestHandlers = new Set<(request: unknown) => void>();
+    const cleanupNotificationHandler = vi.fn<() => void>();
+    const cleanupRequestHandler = vi.fn<() => void>();
+    const now = Date.now() / 1000;
+    const appThread = {
+      id: "app-thread-cancelled-stream",
+      createdAt: now,
+      cwd: workspacePath,
+      modelProvider: "gpt-5.5",
+      name: "Cancelled stream",
+      preview: "Cancelled stream",
+      source: "app",
+      status: { type: "active" },
+      turns: [],
+      updatedAt: now,
+    };
+    const appServer = {
+      onNotification(handler: (notification: unknown) => void) {
+        notificationHandlers.add(handler);
+        return () => {
+          cleanupNotificationHandler();
+          notificationHandlers.delete(handler);
+        };
+      },
+      onRequest(handler: (request: unknown) => void) {
+        requestHandlers.add(handler);
+        return () => {
+          cleanupRequestHandler();
+          requestHandlers.delete(handler);
+        };
+      },
+      readThread: vi.fn<() => Promise<unknown>>(async () => appThread),
+    };
+    const app = createApp({
+      appServer: appServer as never,
+      codex: createMockCodex(),
+      workspacePath,
+    });
+    let reader: ReadableStreamDefaultReader<Uint8Array> | undefined;
+
+    try {
+      for (let attachment = 1; attachment <= 3; attachment += 1) {
+        const response = await app.request("/v1/threads/app-thread-cancelled-stream/runs/stream", {
+          method: "POST",
+          body: JSON.stringify({}),
+          headers: { "content-type": "application/json" },
+        });
+        reader = response.body?.getReader();
+        expect(reader).toBeDefined();
+        await reader!.read();
+        await vi.advanceTimersByTimeAsync(0);
+
+        expect(fetchPreview).toHaveBeenCalledTimes(attachment);
+        expect(notificationHandlers).toHaveLength(1);
+        expect(requestHandlers).toHaveLength(1);
+
+        await reader!.cancel("test cancellation");
+        reader = undefined;
+
+        expect(probeSignals[attachment - 1]?.aborted).toBe(true);
+        await vi.advanceTimersByTimeAsync(4500);
+        expect(fetchPreview).toHaveBeenCalledTimes(attachment);
+        expect(notificationHandlers).toHaveLength(0);
+        expect(requestHandlers).toHaveLength(0);
+        expect(cleanupNotificationHandler).toHaveBeenCalledTimes(attachment);
+        expect(cleanupRequestHandler).toHaveBeenCalledTimes(attachment);
+      }
+    } finally {
+      await reader?.cancel().catch(() => undefined);
+      vi.clearAllTimers();
+      vi.useRealTimers();
+      vi.unstubAllGlobals();
+      if (previousPreviewPorts === undefined) {
+        delete process.env.CODEX_RELAY_WEB_PREVIEW_PORTS;
+      } else {
+        process.env.CODEX_RELAY_WEB_PREVIEW_PORTS = previousPreviewPorts;
+      }
+    }
+  });
+
+  it("stops scanning after detecting the first configured web preview target", async () => {
+    vi.useFakeTimers();
+    const previousPreviewPorts = process.env.CODEX_RELAY_WEB_PREVIEW_PORTS;
+    process.env.CODEX_RELAY_WEB_PREVIEW_PORTS = "65533,65534";
+    const fetchPreview = vi.fn<typeof fetch>(
+      async () =>
+        new Response("<!doctype html><html><title>Preview</title></html>", {
+          headers: { "content-type": "text/html" },
+          status: 200,
+        }),
+    );
+    vi.stubGlobal("fetch", fetchPreview);
+
+    const workspacePath = await mkdtemp(join(tmpdir(), "codex-relay-workspace-"));
+    const notificationHandlers = new Set<(notification: unknown) => void>();
+    const requestHandlers = new Set<(request: unknown) => void>();
+    const now = Date.now() / 1000;
+    const appThread = {
+      id: "app-thread-preview-detected",
+      createdAt: now,
+      cwd: workspacePath,
+      modelProvider: "gpt-5.5",
+      name: "Preview detected",
+      preview: "Preview detected",
+      source: "app",
+      status: { type: "active" },
+      turns: [],
+      updatedAt: now,
+    };
+    const appServer = {
+      onNotification(handler: (notification: unknown) => void) {
+        notificationHandlers.add(handler);
+        return () => notificationHandlers.delete(handler);
+      },
+      onRequest(handler: (request: unknown) => void) {
+        requestHandlers.add(handler);
+        return () => requestHandlers.delete(handler);
+      },
+      readThread: vi.fn<() => Promise<unknown>>(async () => appThread),
+    };
+    const app = createApp({
+      appServer: appServer as never,
+      codex: createMockCodex(),
+      workspacePath,
+    });
+    let reader: ReadableStreamDefaultReader<Uint8Array> | undefined;
+
+    try {
+      const response = await app.request("/v1/threads/app-thread-preview-detected/runs/stream", {
+        method: "POST",
+        body: JSON.stringify({}),
+        headers: { "content-type": "application/json" },
+      });
+      reader = response.body?.getReader();
+      expect(reader).toBeDefined();
+      const decoder = new TextDecoder();
+      let streamedText = "";
+      for (let reads = 0; reads < 6 && !streamedText.includes('"port":65533'); reads += 1) {
+        const result = await reader!.read();
+        expect(result.done).toBe(false);
+        streamedText += decoder.decode(result.value, { stream: true });
+      }
+
+      expect(streamedText).toContain('"port":65533');
+      expect(streamedText.match(/"type":"thread\.preview_target\.detected"/g)).toHaveLength(1);
+      expect(fetchPreview).toHaveBeenCalledTimes(2);
+      await vi.advanceTimersByTimeAsync(4500);
+      expect(fetchPreview).toHaveBeenCalledTimes(2);
+    } finally {
+      await reader?.cancel().catch(() => undefined);
+      vi.clearAllTimers();
+      vi.useRealTimers();
+      vi.unstubAllGlobals();
+      if (previousPreviewPorts === undefined) {
+        delete process.env.CODEX_RELAY_WEB_PREVIEW_PORTS;
+      } else {
+        process.env.CODEX_RELAY_WEB_PREVIEW_PORTS = previousPreviewPorts;
+      }
+    }
   });
 
   it("keeps attached running app-server streams alive through transient idle status", async () => {


### PR DESCRIPTION
## What problem this fixes

When a phone or browser stopped reading a running thread, Relay closed the visible connection but left that connection's web preview checks running in the background.

Each abandoned connection kept requesting every possible local preview every 1.5 seconds, even after it had already found one. Reconnecting could add another set of checks.

During the day today (July 22), this repeated traffic overloaded my local Next.js dev server, drove severe memory pressure, and contributed to the host becoming unresponsive.

## What changed

- Stop scheduled web preview checks as soon as their thread connection ends.
- Cancel any preview request already in progress.
- Stop watching for server updates on behalf of an abandoned connection.
- Use one safe shutdown path for normal completion, client disconnection, and session clearing.
- Wait for each preview scan to finish before scheduling another, so scans cannot overlap.
- Stop checking after the first working preview is found and sent to the mobile app.

The underlying Codex task still continues if the mobile connection drops. This change only removes the unused connection and its preview checks.

## User impact

There are no mobile UI or API changes. Web previews should appear as before. Behind the scenes, Relay now selects the first working configured preview and stops checking, instead of continuing to request preview pages indefinitely.

## Validation

- Added coverage for three repeated connect-and-disconnect cycles, confirming that no preview checks or server-update watchers remain after each disconnect.
- Added coverage for normal completion and for stopping after the first working preview.
- `pnpm test` — 250 passed, 4 skipped.
- `pnpm typecheck` — passed.
- `pnpm lint` — passed with no warnings or errors.
- `pnpm build` — passed.
