### PR TITLE
feat: add background relay stop command

### DIFF
--- a/.changeset/soft-lions-stop.md
+++ b/.changeset/soft-lions-stop.md
@@ -1,0 +1,5 @@
+---
+"codex-relay": minor
+---
+
+Upgrade the Codex SDK to 0.145.0, add an idempotent `stop` command for background relays, and recover shared app-server startup when a stale Unix socket is present.

--- a/packages/codex-relay/README.md
+++ b/packages/codex-relay/README.md
@@ -79,10 +79,10 @@ Print the current pairing QR again:
 npx codex-relay@latest qr
 ```
 
-Stop a background server with the printed process id:
+Stop a background server:
 
 ```sh
-kill -TERM <pid>
+npx codex-relay@latest stop
 ```
 
 ## Commands
@@ -98,6 +98,12 @@ npx codex-relay@latest --bg
 ```
 
 Start the relay in the background.
+
+```sh
+npx codex-relay@latest stop
+```
+
+Stop the background relay. Repeating this command is safe when no background server is running.
 
 ```sh
 npx codex-relay@latest --shared-app-server
@@ -174,7 +180,7 @@ npx codex-relay@latest qr
 Or stop the background process shown by the CLI:
 
 ```sh
-kill -TERM <pid>
+npx codex-relay@latest stop
 ```
 
 If the mobile app cannot connect, confirm that the phone can reach the printed `Mobile:` URL and that the chosen port is not blocked by a firewall.

--- a/packages/codex-relay/package.json
+++ b/packages/codex-relay/package.json
@@ -49,7 +49,7 @@
     "@noble/ciphers": "2.2.0",
     "@noble/curves": "2.2.0",
     "@noble/hashes": "2.2.0",
-    "@openai/codex-sdk": "0.144.5",
+    "@openai/codex-sdk": "0.145.0",
     "base64-js": "1.5.1",
     "commander": "^14.0.3",
     "es-git": "^0.6.0",

--- a/packages/codex-relay/src/app-server.ts
+++ b/packages/codex-relay/src/app-server.ts
@@ -1,5 +1,4 @@
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
-import { access } from "node:fs/promises";
 import { connect } from "node:net";
 import { homedir } from "node:os";
 import { join } from "node:path";
@@ -810,14 +809,11 @@ async function startSharedCodexAppServer() {
 }
 
 async function waitForSharedCodexAppServer(remoteAddress: string) {
-  if (remoteAddress === "unix://") {
-    await access(sharedCodexAppServerSocketPath());
-    return;
-  }
-
-  const url = new URL(remoteAddress);
   await new Promise<void>((resolve, reject) => {
-    const socket = connect({ host: url.hostname, port: Number(url.port) });
+    const socket =
+      remoteAddress === "unix://"
+        ? connect({ path: sharedCodexAppServerSocketPath() })
+        : connectRemoteAddress(remoteAddress);
     const onError = (error: Error) => reject(error);
     socket.once("error", onError);
     socket.once("connect", () => {
@@ -826,6 +822,11 @@ async function waitForSharedCodexAppServer(remoteAddress: string) {
       resolve();
     });
   });
+}
+
+function connectRemoteAddress(remoteAddress: string) {
+  const url = new URL(remoteAddress);
+  return connect({ host: url.hostname, port: Number(url.port) });
 }
 
 function sharedCodexAppServerSocketPath() {

--- a/packages/codex-relay/src/background-process.ts
+++ b/packages/codex-relay/src/background-process.ts
@@ -1,16 +1,29 @@
 import { execFile } from "node:child_process";
-import { readFile } from "node:fs/promises";
+import { readFile, rm } from "node:fs/promises";
+import { setTimeout } from "node:timers/promises";
 import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFile);
 
 type ProcessCommandReader = (pid: number) => Promise<string | undefined>;
 type ProcessAliveChecker = (pid: number) => boolean;
+type ProcessSignaler = (pid: number) => void;
+type ProcessExitWaiter = (pid: number) => Promise<boolean>;
 
 type ReadRunningRelayPidOptions = {
   readonly commandReader?: ProcessCommandReader;
   readonly isProcessAlive?: ProcessAliveChecker;
 };
+
+type StopRunningRelayOptions = ReadRunningRelayPidOptions & {
+  readonly signalProcess?: ProcessSignaler;
+  readonly waitForProcessExit?: ProcessExitWaiter;
+};
+
+export type StopRunningRelayResult =
+  | { readonly kind: "not-running" }
+  | { readonly kind: "stopped"; readonly pid: number }
+  | { readonly kind: "timed-out"; readonly pid: number };
 
 export async function readRunningRelayPid(
   pidPath: string,
@@ -32,6 +45,27 @@ export async function readRunningRelayPid(
   return command && isRelayProcessCommand(command) ? pid : undefined;
 }
 
+export async function stopRunningRelay(
+  pidPath: string,
+  options: StopRunningRelayOptions = {},
+): Promise<StopRunningRelayResult> {
+  const pid = await readRunningRelayPid(pidPath, options);
+  if (!pid) {
+    await rm(pidPath, { force: true });
+    return { kind: "not-running" };
+  }
+
+  const signalProcess = options.signalProcess ?? signalRelayProcess;
+  signalProcess(pid);
+  const waitForProcessExit = options.waitForProcessExit ?? waitForRelayProcessExit;
+  if (!(await waitForProcessExit(pid))) {
+    return { kind: "timed-out", pid };
+  }
+
+  await rm(pidPath, { force: true });
+  return { kind: "stopped", pid };
+}
+
 function defaultIsProcessAlive(pid: number) {
   try {
     process.kill(pid, 0);
@@ -39,6 +73,27 @@ function defaultIsProcessAlive(pid: number) {
   } catch {
     return false;
   }
+}
+
+function signalRelayProcess(pid: number) {
+  try {
+    process.kill(pid, "SIGTERM");
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ESRCH") {
+      return;
+    }
+    throw error;
+  }
+}
+
+async function waitForRelayProcessExit(pid: number) {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    if (!defaultIsProcessAlive(pid)) {
+      return true;
+    }
+    await setTimeout(50);
+  }
+  return false;
 }
 
 async function readProcessCommand(pid: number) {

--- a/packages/codex-relay/src/cli.ts
+++ b/packages/codex-relay/src/cli.ts
@@ -10,7 +10,11 @@ import { setTimeout } from "node:timers/promises";
 import { fileURLToPath } from "node:url";
 
 import { apiPaths } from "./api-schema.js";
-import { readRunningRelayPid } from "./background-process.js";
+import {
+  readRunningRelayPid,
+  stopRunningRelay,
+  type StopRunningRelayResult,
+} from "./background-process.js";
 import { createTursoPairingSessionStore } from "./pairing-store.js";
 import { getConnectUrlGuidance } from "./pairing-url-candidates.js";
 
@@ -53,6 +57,7 @@ Examples:
   ${npxCommand}              Start the relay and print a pairing QR
   ${npxCommand} --shared-app-server Share live sessions with a connected terminal
   ${npxCommand} --bg         Start the relay in the background
+  ${npxCommand} stop         Stop the background relay
   ${npxCommand} qr           Print the current pairing QR
   ${npxCommand} clear        Sign out every paired mobile app
   ${npxCommand} approve CODE Approve a pending mobile pairing request`,
@@ -74,6 +79,13 @@ Examples:
     }
 
     await import("./index.js").catch(handleServerStartError);
+  });
+
+program
+  .command("stop")
+  .description("Stop the background Codex Relay server.")
+  .action(async () => {
+    await stopBackgroundServer();
   });
 
 program
@@ -151,6 +163,7 @@ async function startBackgroundServer() {
     console.log(`Debug logs: ${debugLogPath}`);
   }
   console.log(`Print the pairing QR later with: ${npxCommand} qr`);
+  console.log(`Stop the background relay with: ${npxCommand} stop`);
 }
 
 function backgroundArgs() {
@@ -175,6 +188,32 @@ async function waitForBackgroundPid(child: ReturnType<typeof spawn>, pidPath: st
   }
 
   return undefined;
+}
+
+async function stopBackgroundServer() {
+  const result = await stopRunningRelay(codexRelayDataPath("server.pid"));
+  printStopResult(result);
+}
+
+function printStopResult(result: StopRunningRelayResult) {
+  switch (result.kind) {
+    case "not-running":
+      console.log("No background Codex Relay server is running.");
+      return;
+    case "stopped":
+      console.log(`Stopped codex-relay background server (pid ${result.pid}).`);
+      return;
+    case "timed-out":
+      console.error(`Timed out stopping codex-relay background server (pid ${result.pid}).`);
+      process.exitCode = 1;
+      return;
+    default:
+      return assertNever(result);
+  }
+}
+
+function assertNever(value: never): never {
+  throw new TypeError(`Unexpected background stop result: ${JSON.stringify(value)}`);
 }
 
 async function approvePairing(rawCode: string | undefined) {
@@ -394,7 +433,7 @@ async function handleServerStartError(error: unknown) {
     console.error(`  ${npxCommand} qr`);
     console.error("");
     console.error("To stop the background server:");
-    console.error(`  kill -TERM ${existingPid}`);
+    console.error(`  ${npxCommand} stop`);
     console.error("");
     console.error(`Logs: ${logPath}`);
   } else {

--- a/packages/codex-relay/src/index.ts
+++ b/packages/codex-relay/src/index.ts
@@ -207,6 +207,7 @@ function formatStartupInstructions(details: {
     `${color.prompt("›")} Commands`,
     `  ${color.command(npxCommand)}              Start and print a pairing QR`,
     `  ${color.command(`${npxCommand} --bg`)}         Start in the background`,
+    `  ${color.command(`${npxCommand} stop`)}         Stop the background relay`,
     `  ${color.command(`${npxCommand} qr`)}           Print this QR again`,
     `  ${color.command(`${npxCommand} approve <code>`)} Approve a device`,
     "",

--- a/packages/codex-relay/test/app-server.test.ts
+++ b/packages/codex-relay/test/app-server.test.ts
@@ -82,15 +82,18 @@ describe("CodexAppServerClient shared socket mode", () => {
   });
 
   it.skipIf(process.platform === "win32")(
-    "waits for a slow shared app-server to create its Unix socket",
+    "replaces a stale Unix socket after a slow shared app-server startup",
     async () => {
-      // Given: a real child process that needs four seconds before its socket is ready.
+      // Given: a stale socket path and a real child that needs four seconds before listening.
       const codexHome = await mkdtemp(join(socketTempRoot, "codex-relay-slow-app-server-"));
       const fakeCodexBinary = join(codexHome, "fake-codex");
+      const socketPath = join(codexHome, "app-server-control", "app-server-control.sock");
+      await mkdir(dirname(socketPath), { recursive: true });
+      await writeFile(socketPath, "");
       await writeFile(
         fakeCodexBinary,
         `#!/usr/bin/env node
-import { mkdir } from "node:fs/promises";
+import { mkdir, rm } from "node:fs/promises";
 import { createServer } from "node:http";
 import { join } from "node:path";
 import { setTimeout } from "node:timers/promises";
@@ -99,6 +102,7 @@ import { WebSocketServer } from ${JSON.stringify(import.meta.resolve("ws"))};
 await setTimeout(4_000);
 const socketPath = join(process.env.CODEX_HOME, "app-server-control", "app-server-control.sock");
 await mkdir(join(process.env.CODEX_HOME, "app-server-control"), { recursive: true });
+await rm(socketPath, { force: true });
 const server = createServer();
 const webSocketServer = new WebSocketServer({ server });
 webSocketServer.on("connection", (socket) => {
@@ -130,7 +134,7 @@ process.stdin.resume();
         // When: the relay initializes its shared app-server client.
         await client.initialize();
 
-        // Then: it connects after the slow startup instead of timing out at 2.5 seconds.
+        // Then: it waits for a real listener instead of treating the stale path as ready.
         await expect(client.listModels()).resolves.toEqual([]);
       } finally {
         client.close();

--- a/packages/codex-relay/test/app.test.ts
+++ b/packages/codex-relay/test/app.test.ts
@@ -5596,9 +5596,9 @@ describe("Codex Relay server routes", () => {
         params: { status: "completed", threadId: "app-thread-queue", turnId: "turn-1" },
       });
     }
-    await new Promise<void>((resolve) => queueMicrotask(() => resolve()));
-
-    expect(startTurn).toHaveBeenCalledTimes(2);
+    await vi.waitFor(() => {
+      expect(startTurn).toHaveBeenCalledTimes(2);
+    });
     expect(startTurn).toHaveBeenNthCalledWith(
       2,
       expect.objectContaining({
@@ -5621,9 +5621,9 @@ describe("Codex Relay server routes", () => {
         params: { status: "completed", threadId: "app-thread-queue", turnId: "turn-2" },
       });
     }
-    await new Promise<void>((resolve) => queueMicrotask(() => resolve()));
-
-    expect(startTurn).toHaveBeenCalledTimes(3);
+    await vi.waitFor(() => {
+      expect(startTurn).toHaveBeenCalledTimes(3);
+    });
 
     for (const handler of notificationHandlers) {
       handler({

--- a/packages/codex-relay/test/background-process.test.ts
+++ b/packages/codex-relay/test/background-process.test.ts
@@ -1,10 +1,10 @@
-import { mkdtemp, writeFile } from "node:fs/promises";
+import { access, mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
 
-import { readRunningRelayPid } from "../src/background-process.js";
+import { readRunningRelayPid, stopRunningRelay } from "../src/background-process.js";
 
 describe("background relay pid detection", () => {
   it("ignores a live pid when the process is not codex-relay", async () => {
@@ -28,6 +28,41 @@ describe("background relay pid detection", () => {
     });
 
     expect(pid).toBe(77542);
+  });
+
+  it("signals a validated relay process and removes its pid file", async () => {
+    // Given: a pid file that belongs to a live Codex Relay process.
+    const pidPath = await writePidFile("77542");
+    const signaledPids: number[] = [];
+
+    // When: the background relay is stopped.
+    const result = await stopRunningRelay(pidPath, {
+      commandReader: async () => "node dist/cli.js codex-relay",
+      isProcessAlive: () => true,
+      signalProcess: (pid) => {
+        signaledPids.push(pid);
+      },
+      waitForProcessExit: async () => true,
+    });
+
+    // Then: the owned process is signaled and its stale pid state is cleared.
+    expect(result).toEqual({ kind: "stopped", pid: 77542 });
+    expect(signaledPids).toEqual([77542]);
+    await expect(access(pidPath)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("clears a stale pid file when no background relay is running", async () => {
+    // Given: a pid file whose process no longer exists.
+    const pidPath = await writePidFile("77542");
+
+    // When: the background relay stop command is repeated.
+    const result = await stopRunningRelay(pidPath, {
+      isProcessAlive: () => false,
+    });
+
+    // Then: stop is idempotent and clears the stale pid state.
+    expect(result).toEqual({ kind: "not-running" });
+    await expect(access(pidPath)).rejects.toMatchObject({ code: "ENOENT" });
   });
 });
 

--- a/packages/codex-relay/test/relay-watchdog-command.test.ts
+++ b/packages/codex-relay/test/relay-watchdog-command.test.ts
@@ -10,15 +10,29 @@ describe("relay watchdog service command", () => {
   it("keeps the relay server in watch mode for local library development", () => {
     const command = relayServiceCommand(["--dangerously-auto-approve"]);
 
-    expect(command.args).toEqual([
-      "--filter",
-      "codex-relay",
-      "exec",
-      "tsx",
-      "watch",
-      "src/cli.ts",
-      "--dangerously-auto-approve",
-    ]);
+    expect(command).toEqual({
+      args: [
+        "--filter",
+        "codex-relay",
+        "exec",
+        "tsx",
+        "watch",
+        "src/cli.ts",
+        "--dangerously-auto-approve",
+      ],
+      command: "pnpm",
+      persistent: true,
+    });
+  });
+
+  it("runs the stop command once without a file watcher", () => {
+    const command = relayServiceCommand(["stop"]);
+
+    expect(command).toEqual({
+      args: ["--filter", "codex-relay", "exec", "tsx", "src/cli.ts", "stop"],
+      command: "pnpm",
+      persistent: false,
+    });
   });
 
   it("checks the relay version endpoint on the configured host and port", () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -313,8 +313,8 @@ importers:
         specifier: 2.2.0
         version: 2.2.0
       '@openai/codex-sdk':
-        specifier: 0.144.5
-        version: 0.144.5
+        specifier: 0.145.0
+        version: 0.145.0
       base64-js:
         specifier: 1.5.1
         version: 1.5.1
@@ -2339,47 +2339,47 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@openai/codex-sdk@0.144.5':
-    resolution: {integrity: sha512-90wHPEGyk74On6gwQPNtw+wzuDJ2zYpiVADDxw43S1cWn3QbBh/21zFS2xlAWWCrdY0gE90yXfmmrzwdUDlBGw==}
+  '@openai/codex-sdk@0.145.0':
+    resolution: {integrity: sha512-lBviqBKnomEXNpdjfDzUoz/H+VZuK75m2oR8dQSmL2zUpnklfAsTneuaSg23NOoE+vw/Qhbxp8ePy9te973yfw==}
     engines: {node: '>=18'}
 
-  '@openai/codex@0.144.5':
-    resolution: {integrity: sha512-jjB+K+OMv572mKhS+2QuLxWXDJNdpwbPenf+V+8bdq7wg4Scqt3cn6WEekD8wPqDVZqck0HSX17K9rD9kbDJQA==}
+  '@openai/codex@0.145.0':
+    resolution: {integrity: sha512-/PSPSFujjjmiyVFvG2yu/grOFhsWdokTH8t2KGWhXSo/M5n/dIDsnbsnO82/7bLtIoDuzQf7ATBUMWqPWQINlQ==}
     engines: {node: '>=16'}
     hasBin: true
 
-  '@openai/codex@0.144.5-darwin-arm64':
-    resolution: {integrity: sha512-zcT6NfBCqLFt+BReNSETTZW6v6PdbH0dzNtm9j7l7mDGqwPbKZDGJdnpkBao2389I0ZacyIKgSZoI0vez1d4Dw==}
+  '@openai/codex@0.145.0-darwin-arm64':
+    resolution: {integrity: sha512-h6aQ0UxnaP8mIM/9/qPAH9MNkRliJo88toq1T36IxNM2L5JSU0TFamu+MZn7YkFgDsrp0RfiI+97Tm8AVVxqtA==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [darwin]
 
-  '@openai/codex@0.144.5-darwin-x64':
-    resolution: {integrity: sha512-//Mo0m1MwaoT6psu5xsmofXpKx4/0irIkeq10xJvk59+886EG355ibjA+ZmlRcKhE3bLjsKD7p81nTbAdRL/bw==}
+  '@openai/codex@0.145.0-darwin-x64':
+    resolution: {integrity: sha512-FCYzVKCa9VoLtg9gVyzKpqylonfgZrfcWZN6HsXAZPeuo8CukdMqdgTUOhDn2V6h3MbqS0z6VqQVKUllN/yKhA==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [darwin]
 
-  '@openai/codex@0.144.5-linux-arm64':
-    resolution: {integrity: sha512-zAHggxVwR2TBxKmybXY7ZMiB0G8DMonY2YPdwNNjwXcf+LOIqNGgswwNCDMbP/HEe6r8j+R9ZX/yYoo8f+n/RQ==}
+  '@openai/codex@0.145.0-linux-arm64':
+    resolution: {integrity: sha512-8OLcPXaAol/FOrRoDxWhIiHIFa73KRsM41EKocjRZOwiT4TcelzJWn3dHyiuSb7teWF25rrslvSPyvhULYRRCQ==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [linux]
 
-  '@openai/codex@0.144.5-linux-x64':
-    resolution: {integrity: sha512-FalLJlBQGFdK8Gc3kj9sa/ekNdgkHhUawLaKkvy5CtB18JaP2YxtTP/Pe1pD2iBiq8mMUliRnafpF6AdBdQMbg==}
+  '@openai/codex@0.145.0-linux-x64':
+    resolution: {integrity: sha512-u8w8LLv3DvsfrDCoswLIemZ0SoNEXyi511WsfFsSiYUazk9qMsB/NtU8N9vhAfN7mZAxLFoMex4v66JjHuZWwA==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [linux]
 
-  '@openai/codex@0.144.5-win32-arm64':
-    resolution: {integrity: sha512-0Pj7iqjEOEvPQPO3kFfCy9vGX4BTu76ChFFZHr2eNNIfVc3FOENAv/X98u4L+iIUtDOK9DbqmfUudW3DPapshg==}
+  '@openai/codex@0.145.0-win32-arm64':
+    resolution: {integrity: sha512-sub61rjEFevi1i3Zx7nAd4JM5XxoNFqMqFc5LfTo2xSI8ixHjFvEYDFDXwXOftT04n3Ht1Wh271ioUZpDiEjEg==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [win32]
 
-  '@openai/codex@0.144.5-win32-x64':
-    resolution: {integrity: sha512-DnsSTlnnzleTxvLwIGnBitKInscxn2I7qASqosS8Fv+qysBygd+ZiBn/SQsRCgQ28PAlsNzmd3Gf3ZTecolAmg==}
+  '@openai/codex@0.145.0-win32-x64':
+    resolution: {integrity: sha512-u0h9lk094CaXRSqE34SBW2dRaQTPa6fASXqehczWH9QdsU62mBsiAgAdp6tCG4i+YzPmmhjD8FdXNnYGNmwuMg==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
@@ -10002,35 +10002,35 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
-  '@openai/codex-sdk@0.144.5':
+  '@openai/codex-sdk@0.145.0':
     dependencies:
-      '@openai/codex': 0.144.5
+      '@openai/codex': 0.145.0
 
-  '@openai/codex@0.144.5':
+  '@openai/codex@0.145.0':
     optionalDependencies:
-      '@openai/codex-darwin-arm64': '@openai/codex@0.144.5-darwin-arm64'
-      '@openai/codex-darwin-x64': '@openai/codex@0.144.5-darwin-x64'
-      '@openai/codex-linux-arm64': '@openai/codex@0.144.5-linux-arm64'
-      '@openai/codex-linux-x64': '@openai/codex@0.144.5-linux-x64'
-      '@openai/codex-win32-arm64': '@openai/codex@0.144.5-win32-arm64'
-      '@openai/codex-win32-x64': '@openai/codex@0.144.5-win32-x64'
+      '@openai/codex-darwin-arm64': '@openai/codex@0.145.0-darwin-arm64'
+      '@openai/codex-darwin-x64': '@openai/codex@0.145.0-darwin-x64'
+      '@openai/codex-linux-arm64': '@openai/codex@0.145.0-linux-arm64'
+      '@openai/codex-linux-x64': '@openai/codex@0.145.0-linux-x64'
+      '@openai/codex-win32-arm64': '@openai/codex@0.145.0-win32-arm64'
+      '@openai/codex-win32-x64': '@openai/codex@0.145.0-win32-x64'
 
-  '@openai/codex@0.144.5-darwin-arm64':
+  '@openai/codex@0.145.0-darwin-arm64':
     optional: true
 
-  '@openai/codex@0.144.5-darwin-x64':
+  '@openai/codex@0.145.0-darwin-x64':
     optional: true
 
-  '@openai/codex@0.144.5-linux-arm64':
+  '@openai/codex@0.145.0-linux-arm64':
     optional: true
 
-  '@openai/codex@0.144.5-linux-x64':
+  '@openai/codex@0.145.0-linux-x64':
     optional: true
 
-  '@openai/codex@0.144.5-win32-arm64':
+  '@openai/codex@0.145.0-win32-arm64':
     optional: true
 
-  '@openai/codex@0.144.5-win32-x64':
+  '@openai/codex@0.145.0-win32-x64':
     optional: true
 
   '@oxc-project/types@0.127.0': {}

--- a/scripts/relay-watchdog-command.mjs
+++ b/scripts/relay-watchdog-command.mjs
@@ -1,7 +1,17 @@
 export function relayServiceCommand(cliArgs) {
+  const persistent = !cliArgs.includes("stop");
   return {
     command: "pnpm",
-    args: ["--filter", "codex-relay", "exec", "tsx", "watch", "src/cli.ts", ...cliArgs],
+    args: [
+      "--filter",
+      "codex-relay",
+      "exec",
+      "tsx",
+      ...(persistent ? ["watch"] : []),
+      "src/cli.ts",
+      ...cliArgs,
+    ],
+    persistent,
   };
 }
 

--- a/scripts/relay-watchdog.mjs
+++ b/scripts/relay-watchdog.mjs
@@ -22,22 +22,18 @@ await log(`watchdog starting args=${cliArgs.join(" ")}`);
 process.on("SIGINT", stop);
 process.on("SIGTERM", stop);
 
-await runService();
+const serviceCommand = relayServiceCommand(cliArgs);
+if (serviceCommand.persistent) {
+  await runService(serviceCommand);
+} else {
+  await runCommandOnce(serviceCommand);
+}
 await log("watchdog stopped");
 
-async function runService() {
+async function runService(serviceCommand) {
   while (!stopping) {
     const startedAt = Date.now();
-    const serviceCommand = relayServiceCommand(cliArgs);
-    child = spawn(serviceCommand.command, serviceCommand.args, {
-      cwd: root,
-      env: {
-        ...process.env,
-        NODE_ENV: "development",
-        PORT: process.env.CODEX_RELAY_PORT ?? process.env.PORT ?? "8787",
-      },
-      stdio: "inherit",
-    });
+    child = spawnService(serviceCommand);
 
     await log(`server spawned pid=${child.pid}`);
 
@@ -66,6 +62,26 @@ async function runService() {
     );
     await delay(restartDelayMs);
   }
+}
+
+async function runCommandOnce(serviceCommand) {
+  child = spawnService(serviceCommand);
+  await log(`command spawned pid=${child.pid}`);
+  const exit = await waitForExit(child);
+  child = undefined;
+  process.exitCode = exit.code ?? 1;
+}
+
+function spawnService(serviceCommand) {
+  return spawn(serviceCommand.command, serviceCommand.args, {
+    cwd: root,
+    env: {
+      ...process.env,
+      NODE_ENV: "development",
+      PORT: process.env.CODEX_RELAY_PORT ?? process.env.PORT ?? "8787",
+    },
+    stdio: "inherit",
+  });
 }
 
 function waitForExit(runningChild) {


### PR DESCRIPTION
## Summary

- upgrade `@openai/codex-sdk` and the bundled Codex CLI to `0.145.0`
- add an idempotent `codex-relay stop` command that validates the recorded process before sending `SIGTERM`, waits for exit, and removes stale PID state
- make the workspace watchdog run `stop` once instead of keeping it alive under `tsx watch` and restarting it
- probe the shared Unix socket by connecting to its listener, so a stale socket path no longer triggers an immediate `ECONNREFUSED`
- document the new command and add a minor changeset
- stabilize the existing queued-turn test by waiting for the asynchronous handoff instead of assuming it completes in one microtask

## Root cause

Shared app-server startup treated Unix socket path existence as readiness. When an old `app-server-control.sock` inode remained without a listener, the relay immediately attempted its WebSocket connection, received `ECONNREFUSED`, and killed the newly spawned app-server before it could replace the stale endpoint.

The background flow already recorded and validated the relay PID, but exposed no stop command; users had to copy the PID into `kill -TERM` manually.

Closes #8

## Validation

- `pnpm test` — 253 passed, 4 skipped
- `pnpm typecheck`
- `pnpm lint`
- `pnpm --filter codex-relay build`
- reran `pnpm -w codex-relay --dangerously-auto-approve --shared-app-server` against the stale control socket; the relay started, `/version` returned `codex-relay-server`, and the Codex process owned the socket
- started an isolated background relay, verified `/version`, stopped it through `pnpm -w codex-relay stop`, and repeated the command to verify the idempotent no-server path
