### PR TITLE
feat: default to shared app-server on macOS

### DIFF
--- a/.changeset/brave-macs-share.md
+++ b/.changeset/brave-macs-share.md
@@ -1,0 +1,5 @@
+---
+"codex-relay": minor
+---
+
+Prefer the shared Codex app-server on macOS, with automatic private-mode fallback when default shared startup fails. Keep Linux and Windows defaults unchanged, and preserve `--shared-app-server` as a required shared mode.

--- a/packages/codex-relay/README.md
+++ b/packages/codex-relay/README.md
@@ -30,13 +30,17 @@ After approval, the phone can list Codex threads, start new work, stream message
 
 ## Shared Terminal and Mobile Sessions
 
-By default, Codex Relay starts a private app-server process. A terminal TUI that was started separately can resume the same saved thread, but it does not receive the relay process's live events.
+On macOS, Codex Relay prefers Codex's shared Unix socket so terminal and mobile clients can follow the same live sessions. If the shared app-server cannot start or initialize, the relay prints a warning and continues with a private app-server.
 
-Opt in to Codex's shared app-server:
+Linux, WSL, and native Windows keep using a private app-server by default. A terminal TUI that was started separately can resume the same saved thread, but it does not receive the relay process's live events.
+
+Require the shared app-server on any platform:
 
 ```sh
 npx codex-relay@latest --shared-app-server
 ```
+
+This explicit mode does not fall back to a private app-server when shared startup fails.
 
 When a shared app-server is already running, the relay attaches to it instead of starting another one. If the relay's own socket connection resets, it reconnects without deliberately stopping the shared app-server.
 
@@ -56,7 +60,7 @@ Pass a thread ID after the remote endpoint to open a specific thread. The relay 
 
 Shared mode uses Codex's experimental app-server transport. A directly connected terminal TUI has its own WebSocket connection, which the relay cannot observe or reconnect. If that terminal reports a socket reset while the thread continues on mobile, reconnect it with the matching remote endpoint above and append the thread ID if needed.
 
-Shared mode requires a recent Codex CLI with app-server and `resume --remote` support. It uses a Unix socket on macOS, Linux, and WSL, or a loopback-only WebSocket on Windows. If those features are unavailable, update Codex or omit `--shared-app-server` to keep the existing private mode.
+Shared mode requires a recent Codex CLI with app-server and `resume --remote` support. It uses a Unix socket on macOS, Linux, and WSL, or a loopback-only WebSocket on Windows. If explicit shared mode is unavailable, update Codex or omit `--shared-app-server`. On macOS, set `CODEX_RELAY_APP_SERVER_MODE=stdio` to force private mode instead of using the shared-first default.
 
 ## Background Mode
 
@@ -109,7 +113,7 @@ Stop the background relay. Repeating this command is safe when no background ser
 npx codex-relay@latest --shared-app-server
 ```
 
-Start the relay through Codex's shared app-server socket.
+Require the relay to start through Codex's shared app-server socket.
 
 ```sh
 npx codex-relay@latest qr
@@ -133,17 +137,17 @@ Start the relay and automatically approve mobile pairing requests. Use this only
 
 The relay listens on `0.0.0.0:8787` by default. Configure it with environment variables:
 
-| Variable                               | Purpose                                                                                            |
-| -------------------------------------- | -------------------------------------------------------------------------------------------------- |
-| `PORT`                                 | Server port. Defaults to `8787`.                                                                   |
-| `HOST`                                 | Listen host. Defaults to `0.0.0.0`.                                                                |
-| `CODEX_RELAY_WORKSPACE_PATH`           | Workspace path Codex should use. Defaults to the directory where you run `npx codex-relay@latest`. |
-| `CODEX_RELAY_AUTH_DB_PATH`             | Pairing and session database path. Defaults to `.codex-relay/auth.db`.                             |
-| `CODEX_RELAY_APPROVAL_SECRET`          | Secret used by the local approve command. Usually generated automatically.                         |
-| `CODEX_RELAY_DANGEROUSLY_AUTO_APPROVE` | Set to `1` to auto-approve mobile pairing requests. Prefer the CLI flag for local use.             |
-| `CODEX_RELAY_APP_SERVER_MODE`          | Set to `socket` for shared terminal/mobile sessions. Defaults to `stdio`.                          |
-| `CODEX_HOME`                           | Codex home directory, used when reading Codex session metadata.                                    |
-| `CODEX_BIN`                            | Codex CLI executable path.                                                                         |
+| Variable                               | Purpose                                                                                                                                                         |
+| -------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `PORT`                                 | Server port. Defaults to `8787`.                                                                                                                                |
+| `HOST`                                 | Listen host. Defaults to `0.0.0.0`.                                                                                                                             |
+| `CODEX_RELAY_WORKSPACE_PATH`           | Workspace path Codex should use. Defaults to the directory where you run `npx codex-relay@latest`.                                                              |
+| `CODEX_RELAY_AUTH_DB_PATH`             | Pairing and session database path. Defaults to `.codex-relay/auth.db`.                                                                                          |
+| `CODEX_RELAY_APPROVAL_SECRET`          | Secret used by the local approve command. Usually generated automatically.                                                                                      |
+| `CODEX_RELAY_DANGEROUSLY_AUTO_APPROVE` | Set to `1` to auto-approve mobile pairing requests. Prefer the CLI flag for local use.                                                                          |
+| `CODEX_RELAY_APP_SERVER_MODE`          | Set to `socket` to require shared mode or `stdio` to require private mode. Unset prefers shared mode with startup fallback on macOS and private mode elsewhere. |
+| `CODEX_HOME`                           | Codex home directory, used when reading Codex session metadata.                                                                                                 |
+| `CODEX_BIN`                            | Codex CLI executable path.                                                                                                                                      |
 
 Examples:
 

--- a/packages/codex-relay/src/app-server.ts
+++ b/packages/codex-relay/src/app-server.ts
@@ -11,6 +11,8 @@ import {
   resolveCodexAppServerSpawn,
   resolveCodexSharedAppServerRemoteAddress,
   resolveCodexSharedAppServerSpawn,
+  type CodexAppServerMode,
+  type CodexAppServerModeResolution,
 } from "./codex-binary.js";
 import { relayDebugLog } from "./debug-log.js";
 
@@ -34,7 +36,9 @@ type PendingRequest = {
 type SharedAppServerOwnership = "attached" | "relay-owned";
 
 export type CodexAppServerClientOptions = {
-  startSharedServer?: () => Promise<ChildProcessWithoutNullStreams>;
+  readonly mode?: CodexAppServerModeResolution;
+  readonly onStartupFallback?: (error: Error) => void;
+  readonly startSharedServer?: () => Promise<ChildProcessWithoutNullStreams>;
 };
 
 const sharedSocketReconnectDelaysMs = [50, 100, 250, 500, 1_000, 2_000] as const;
@@ -254,8 +258,10 @@ export type AppServerThreadGoalClearParams = {
 };
 
 export class CodexAppServerClient {
+  private activeMode: CodexAppServerMode;
   private child: ChildProcessWithoutNullStreams | undefined;
   private closed = false;
+  private fallbackToStdio: boolean;
   private initialized: Promise<void> | undefined;
   private notificationHandlers = new Set<(notification: AppServerNotification) => void>();
   private nextId = 1;
@@ -263,12 +269,22 @@ export class CodexAppServerClient {
   private reconnecting: Promise<void> | undefined;
   private requestHandlers = new Set<(request: AppServerRequest) => void>();
   private readline: Interface | undefined;
+  private sharedReconnectEnabled = false;
   private sharedServer: ChildProcessWithoutNullStreams | undefined;
   private socket: WebSocket | undefined;
-  private startSharedServer: () => Promise<ChildProcessWithoutNullStreams>;
+  private readonly onStartupFallback: ((error: Error) => void) | undefined;
+  private readonly startSharedServer: () => Promise<ChildProcessWithoutNullStreams>;
 
   constructor(options: CodexAppServerClientOptions = {}) {
+    const mode = options.mode ?? resolveCodexAppServerMode();
+    this.activeMode = mode.mode;
+    this.fallbackToStdio = mode.fallbackToStdio;
+    this.onStartupFallback = options.onStartupFallback;
     this.startSharedServer = options.startSharedServer ?? startSharedCodexAppServer;
+  }
+
+  get appServerMode() {
+    return this.activeMode;
   }
 
   initialize() {
@@ -373,15 +389,8 @@ export class CodexAppServerClient {
       pending.reject(new Error("Codex app-server was closed."));
     }
     this.pending.clear();
-    this.readline?.close();
-    this.child?.kill();
-    const socket = this.socket;
-    this.socket = undefined;
-    socket?.close();
-    this.sharedServer?.kill();
-    this.readline = undefined;
-    this.child = undefined;
-    this.sharedServer = undefined;
+    this.stopStdioCodexAppServer();
+    this.stopSharedCodexAppServer();
     this.initialized = undefined;
   }
 
@@ -416,18 +425,37 @@ export class CodexAppServerClient {
   }
 
   private async start() {
-    const mode = resolveCodexAppServerMode();
+    if (this.activeMode === "stdio") {
+      await this.startAndInitializeStdioCodexAppServer();
+      return;
+    }
+
     try {
-      if (mode === "socket") {
-        await this.startOrAttachSharedCodexAppServer();
-      } else {
-        this.startStdioCodexAppServer();
+      await this.startOrAttachSharedCodexAppServer();
+      await this.initializeAppServer();
+      this.fallbackToStdio = false;
+      this.sharedReconnectEnabled = true;
+    } catch (error) {
+      const sharedError = error instanceof Error ? error : new Error(String(error));
+      this.stopSharedCodexAppServer();
+      if (!this.fallbackToStdio) {
+        throw sharedError;
       }
+      this.activeMode = "stdio";
+      relayDebugLog("app_server.shared_socket.startup_fallback", {
+        message: sharedError.message,
+      });
+      this.onStartupFallback?.(sharedError);
+      await this.startAndInitializeStdioCodexAppServer();
+    }
+  }
+
+  private async startAndInitializeStdioCodexAppServer() {
+    try {
+      this.startStdioCodexAppServer();
       await this.initializeAppServer();
     } catch (error) {
-      if (mode === "stdio") {
-        this.stopStdioCodexAppServer();
-      }
+      this.stopStdioCodexAppServer();
       throw error;
     }
   }
@@ -474,6 +502,15 @@ export class CodexAppServerClient {
     this.child = undefined;
   }
 
+  private stopSharedCodexAppServer() {
+    this.sharedReconnectEnabled = false;
+    const socket = this.socket;
+    this.socket = undefined;
+    socket?.close();
+    this.sharedServer?.kill();
+    this.sharedServer = undefined;
+  }
+
   private async startOrAttachSharedCodexAppServer() {
     try {
       await this.connectSharedCodexAppServer();
@@ -483,7 +520,7 @@ export class CodexAppServerClient {
       });
       return;
     } catch (error) {
-      const attachError = asError(error);
+      const attachError = error instanceof Error ? error : new Error(String(error));
       relayDebugLog("app_server.shared_socket.attach_failed", {
         message: attachError.message,
         socketPath: sharedCodexAppServerSocketPath(),
@@ -603,7 +640,7 @@ export class CodexAppServerClient {
   }
 
   private scheduleSharedSocketReconnect() {
-    if (this.closed || this.reconnecting) {
+    if (this.closed || !this.sharedReconnectEnabled || this.reconnecting) {
       return;
     }
     const reconnecting = this.reconnectSharedCodexAppServer();
@@ -635,7 +672,7 @@ export class CodexAppServerClient {
     let lastError: Error | undefined;
     for (const delayMs of sharedSocketReconnectDelaysMs) {
       await setTimeout(delayMs);
-      if (this.closed) {
+      if (this.closed || !this.sharedReconnectEnabled) {
         return;
       }
       try {
@@ -647,7 +684,7 @@ export class CodexAppServerClient {
         });
         return;
       } catch (error) {
-        lastError = asError(error);
+        lastError = error instanceof Error ? error : new Error(String(error));
         const socket = this.socket;
         this.socket = undefined;
         socket?.close();

--- a/packages/codex-relay/src/cli.ts
+++ b/packages/codex-relay/src/cli.ts
@@ -43,7 +43,7 @@ const program = new Command()
   .option("--debug", "write verbose relay diagnostics to debug.log")
   .option(
     "--shared-app-server",
-    "use a shared Codex app-server socket so terminal and mobile can share live sessions",
+    "require a shared Codex app-server so terminal and mobile can share live sessions",
   )
   .option(
     "--dangerously-auto-approve",

--- a/packages/codex-relay/src/codex-binary.ts
+++ b/packages/codex-relay/src/codex-binary.ts
@@ -21,15 +21,27 @@ export type CodexAppServerSpawnInput = {
 
 export type CodexAppServerMode = "stdio" | "socket";
 
+export type CodexAppServerModeResolution = {
+  readonly fallbackToStdio: boolean;
+  readonly mode: CodexAppServerMode;
+};
+
 export function resolveCodexAppServerMode(
-  env: NodeJS.ProcessEnv = process.env,
-): CodexAppServerMode {
+  input: CodexAppServerSpawnInput = {},
+): CodexAppServerModeResolution {
+  const env = input.env ?? process.env;
+  const platform = input.platform ?? currentPlatform();
   const configuredMode = env.CODEX_RELAY_APP_SERVER_MODE?.trim().toLowerCase();
-  if (!configuredMode || configuredMode === "stdio") {
-    return "stdio";
+  if (!configuredMode) {
+    return platform === "darwin"
+      ? { fallbackToStdio: true, mode: "socket" }
+      : { fallbackToStdio: false, mode: "stdio" };
+  }
+  if (configuredMode === "stdio") {
+    return { fallbackToStdio: false, mode: "stdio" };
   }
   if (configuredMode === "socket") {
-    return "socket";
+    return { fallbackToStdio: false, mode: "socket" };
   }
   throw new Error(
     `Unsupported CODEX_RELAY_APP_SERVER_MODE ${JSON.stringify(configuredMode)}. Expected "stdio" or "socket".`,

--- a/packages/codex-relay/src/index.ts
+++ b/packages/codex-relay/src/index.ts
@@ -61,18 +61,29 @@ const preferencesStore = createFileRuntimePreferencesStore(
   process.env.CODEX_RELAY_PREFERENCES_PATH ?? (await prepareCodexRelayDataPath("preferences.json")),
 );
 const appServerMode = resolveCodexAppServerMode();
-const sharedAppServer = appServerMode === "socket" ? new CodexAppServerClient() : undefined;
-if (sharedAppServer) {
-  await sharedAppServer.initialize();
-  process.once("SIGINT", () => stopSharedAppServer(130));
-  process.once("SIGTERM", () => stopSharedAppServer(143));
-  process.once("exit", () => sharedAppServer.close());
+const relayAppServer =
+  appServerMode.mode === "socket"
+    ? new CodexAppServerClient({
+        mode: appServerMode,
+        onStartupFallback: (error) => {
+          logRuntimeEvent(
+            "Fallback",
+            `Shared app-server unavailable; continuing with a private app-server (${error.message}).`,
+          );
+        },
+      })
+    : undefined;
+if (relayAppServer) {
+  await relayAppServer.initialize();
+  process.once("SIGINT", () => stopRelayAppServer(130));
+  process.once("SIGTERM", () => stopRelayAppServer(143));
+  process.once("exit", () => relayAppServer.close());
 }
 
 serve(
   {
     fetch: createApp({
-      appServer: sharedAppServer,
+      appServer: relayAppServer,
       pairing: {
         approvalSecret,
         dangerouslyAutoApprove,
@@ -167,14 +178,16 @@ serve(
         pairingPayload,
         port: info.port,
         sharedAppServerRemoteAddress:
-          appServerMode === "socket" ? resolveCodexSharedAppServerRemoteAddress() : undefined,
+          relayAppServer?.appServerMode === "socket"
+            ? resolveCodexSharedAppServerRemoteAddress()
+            : undefined,
       }),
     );
   },
 );
 
-function stopSharedAppServer(exitCode: number) {
-  sharedAppServer?.close();
+function stopRelayAppServer(exitCode: number) {
+  relayAppServer?.close();
   process.exit(exitCode);
 }
 

--- a/packages/codex-relay/test/app-server-startup.test.ts
+++ b/packages/codex-relay/test/app-server-startup.test.ts
@@ -1,0 +1,206 @@
+import { chmod, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { createServer, type Server } from "node:http";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { WebSocketServer, type WebSocket } from "ws";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../src/debug-log.js", () => ({
+  relayDebugLog: vi.fn<(event: string, fields?: Record<string, unknown>) => void>(),
+}));
+
+import { CodexAppServerClient } from "../src/app-server.js";
+import { relayDebugLog } from "../src/debug-log.js";
+
+type SharedSocketServer = {
+  readonly close: () => Promise<void>;
+};
+
+const socketTempRoot = process.platform === "darwin" ? "/tmp" : tmpdir();
+
+describe("CodexAppServerClient startup mode", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllEnvs();
+  });
+
+  it("falls back to private stdio when default shared startup fails", async () => {
+    // Given: automatic shared mode and a working private stdio app-server.
+    const codexHome = await mkdtemp(join(socketTempRoot, "codex-relay-fallback-app-server-"));
+    const fakeCodexBinary = join(codexHome, "fake-codex");
+    await writeFakeStdioCodexBinary(fakeCodexBinary);
+    vi.stubEnv("CODEX_BIN", fakeCodexBinary);
+    vi.stubEnv("CODEX_HOME", codexHome);
+    const sharedError = new Error("shared startup failed");
+    const startSharedServer = vi.fn<() => Promise<never>>(async () => {
+      throw sharedError;
+    });
+    const onStartupFallback = vi.fn<(error: Error) => void>();
+    const client = new CodexAppServerClient({
+      mode: { fallbackToStdio: true, mode: "socket" },
+      onStartupFallback,
+      startSharedServer,
+    });
+
+    try {
+      // When: the client initializes.
+      await client.initialize();
+
+      // Then: it reports the fallback and continues through private stdio.
+      expect(startSharedServer).toHaveBeenCalledOnce();
+      expect(onStartupFallback).toHaveBeenCalledWith(sharedError);
+      expect(client.appServerMode).toBe("stdio");
+      await expect(client.listModels()).resolves.toEqual([]);
+    } finally {
+      client.close();
+      await rm(codexHome, { force: true, recursive: true });
+    }
+  });
+
+  it("does not fall back when shared mode is explicitly configured", async () => {
+    // Given: forced shared mode whose server cannot start.
+    const codexHome = await mkdtemp(join(socketTempRoot, "codex-relay-forced-app-server-"));
+    vi.stubEnv("CODEX_HOME", codexHome);
+    const sharedError = new Error("forced shared startup failed");
+    const startSharedServer = vi.fn<() => Promise<never>>(async () => {
+      throw sharedError;
+    });
+    const onStartupFallback = vi.fn<(error: Error) => void>();
+    const client = new CodexAppServerClient({
+      mode: { fallbackToStdio: false, mode: "socket" },
+      onStartupFallback,
+      startSharedServer,
+    });
+
+    try {
+      // When: the client initializes.
+      const initialization = client.initialize();
+
+      // Then: the explicit shared-mode failure remains visible.
+      await expect(initialization).rejects.toThrow(sharedError.message);
+      expect(startSharedServer).toHaveBeenCalledOnce();
+      expect(onStartupFallback).not.toHaveBeenCalled();
+      expect(client.appServerMode).toBe("socket");
+    } finally {
+      client.close();
+      await rm(codexHome, { force: true, recursive: true });
+    }
+  });
+
+  it("does not fall back after a shared connection has initialized", async () => {
+    // Given: automatic shared mode that initialized successfully before losing its server.
+    const codexHome = await mkdtemp(join(socketTempRoot, "codex-relay-connected-app-server-"));
+    const fakeCodexBinary = join(codexHome, "fake-codex");
+    const socketPath = join(codexHome, "app-server-control", "app-server-control.sock");
+    await writeFakeStdioCodexBinary(fakeCodexBinary);
+    const server = await startSharedSocketServer(socketPath);
+    vi.stubEnv("CODEX_BIN", fakeCodexBinary);
+    vi.stubEnv("CODEX_HOME", codexHome);
+    const sharedError = new Error("replacement shared startup failed");
+    const startSharedServer = vi.fn<() => Promise<never>>(async () => {
+      throw sharedError;
+    });
+    const onStartupFallback = vi.fn<(error: Error) => void>();
+    const client = new CodexAppServerClient({
+      mode: { fallbackToStdio: true, mode: "socket" },
+      onStartupFallback,
+      startSharedServer,
+    });
+    let serverClosed = false;
+
+    try {
+      await client.initialize();
+      await server.close();
+      serverClosed = true;
+      await vi.waitFor(
+        () => {
+          expect(relayDebugLog).toHaveBeenCalledWith(
+            "app_server.shared_socket.reconnect_failed",
+            expect.objectContaining({ ownership: "attached" }),
+          );
+        },
+        { timeout: 8_000 },
+      );
+
+      // When: a later initialization retries after reconnect exhaustion.
+      const reinitialization = client.initialize();
+
+      // Then: the failure stays in shared mode instead of splitting into private stdio.
+      await expect(reinitialization).rejects.toThrow(sharedError.message);
+      expect(startSharedServer).toHaveBeenCalledOnce();
+      expect(onStartupFallback).not.toHaveBeenCalled();
+      expect(client.appServerMode).toBe("socket");
+    } finally {
+      client.close();
+      if (!serverClosed) {
+        await server.close();
+      }
+      await rm(codexHome, { force: true, recursive: true });
+    }
+  }, 12_000);
+});
+
+async function startSharedSocketServer(socketPath: string): Promise<SharedSocketServer> {
+  await mkdir(dirname(socketPath), { recursive: true });
+  const connections: WebSocket[] = [];
+  const server = createServer();
+  const webSocketServer = new WebSocketServer({ server });
+  webSocketServer.on("connection", (socket) => {
+    connections.push(socket);
+    socket.on("message", (data) => {
+      const request = JSON.parse(String(data)) as { id: number };
+      socket.send(JSON.stringify({ id: request.id, result: {} }));
+    });
+  });
+  await listen(server, socketPath);
+
+  return {
+    async close() {
+      for (const socket of connections) {
+        socket.terminate();
+      }
+      await new Promise<void>((resolve, reject) => {
+        webSocketServer.close((error) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+          server.close((serverError) => {
+            if (serverError) {
+              reject(serverError);
+              return;
+            }
+            resolve();
+          });
+        });
+      });
+    },
+  };
+}
+
+function listen(server: Server, socketPath: string) {
+  return new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(socketPath, () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+}
+
+async function writeFakeStdioCodexBinary(binaryPath: string) {
+  await writeFile(
+    binaryPath,
+    `#!/usr/bin/env node
+import { createInterface } from "node:readline";
+
+const lines = createInterface({ input: process.stdin });
+lines.on("line", (line) => {
+  const request = JSON.parse(line);
+  const result = request.method === "model/list" ? { data: [] } : {};
+  process.stdout.write(\`\${JSON.stringify({ id: request.id, result })}\\n\`);
+});
+`,
+  );
+  await chmod(binaryPath, 0o755);
+}

--- a/packages/codex-relay/test/app-server.test.ts
+++ b/packages/codex-relay/test/app-server.test.ts
@@ -66,6 +66,7 @@ describe("CodexAppServerClient shared socket mode", () => {
       await expect(client.listModels()).resolves.toEqual([]);
       expect(server.requests.filter((request) => request.method === "initialize")).toHaveLength(2);
       expect(startSharedServer).not.toHaveBeenCalled();
+      expect(client.appServerMode).toBe("socket");
       expect(relayDebugLog).toHaveBeenCalledWith(
         "app_server.shared_socket.disconnected",
         expect.objectContaining({ ownership: "attached" }),

--- a/packages/codex-relay/test/codex-binary.test.ts
+++ b/packages/codex-relay/test/codex-binary.test.ts
@@ -7,6 +7,48 @@ import {
 } from "../src/codex-binary.js";
 
 describe("Codex app-server spawn resolution", () => {
+  it("defaults to a shared socket with startup fallback on macOS", () => {
+    // Given: macOS with no explicit app-server mode.
+    // When: the relay resolves its startup mode.
+    const mode = resolveCodexAppServerMode({ env: {}, platform: "darwin" });
+
+    // Then: shared mode is preferred, but private stdio remains the startup fallback.
+    expect(mode).toEqual({ fallbackToStdio: true, mode: "socket" });
+  });
+
+  it.each(["linux", "win32"] as const)("keeps private stdio as the default on %s", (platform) => {
+    // Given: a non-macOS platform with no explicit app-server mode.
+    // When: the relay resolves its startup mode.
+    const mode = resolveCodexAppServerMode({ env: {}, platform });
+
+    // Then: existing private stdio behavior remains unchanged.
+    expect(mode).toEqual({ fallbackToStdio: false, mode: "stdio" });
+  });
+
+  it("forces shared mode without fallback when explicitly configured on macOS", () => {
+    // Given: shared mode explicitly configured on macOS.
+    // When: the relay resolves its startup mode.
+    const mode = resolveCodexAppServerMode({
+      env: { CODEX_RELAY_APP_SERVER_MODE: "socket" },
+      platform: "darwin",
+    });
+
+    // Then: startup failure remains visible to the caller.
+    expect(mode).toEqual({ fallbackToStdio: false, mode: "socket" });
+  });
+
+  it("allows private stdio to be explicitly configured on macOS", () => {
+    // Given: private mode explicitly configured on macOS.
+    // When: the relay resolves its startup mode.
+    const mode = resolveCodexAppServerMode({
+      env: { CODEX_RELAY_APP_SERVER_MODE: "stdio" },
+      platform: "darwin",
+    });
+
+    // Then: shared startup is skipped.
+    expect(mode).toEqual({ fallbackToStdio: false, mode: "stdio" });
+  });
+
   it("uses a shell for the default npm command on Windows", () => {
     const spawnConfig = resolveCodexAppServerSpawn({
       env: {},
@@ -73,9 +115,12 @@ describe("Codex app-server spawn resolution", () => {
   });
 
   it("rejects unknown app-server modes", () => {
-    expect(() => resolveCodexAppServerMode({ CODEX_RELAY_APP_SERVER_MODE: "shared" })).toThrow(
-      'Expected "stdio" or "socket"',
-    );
+    expect(() =>
+      resolveCodexAppServerMode({
+        env: { CODEX_RELAY_APP_SERVER_MODE: "shared" },
+        platform: "darwin",
+      }),
+    ).toThrow('Expected "stdio" or "socket"');
   });
 
   it("listens on a loopback WebSocket in shared mode on native Windows", () => {


### PR DESCRIPTION
## Summary

- prefer Codex's shared Unix-socket app-server when macOS users start the relay without an explicit mode
- fall back to a private stdio app-server only when that default shared startup or initialization fails
- keep Linux, WSL, and native Windows on the existing private stdio default
- preserve `--shared-app-server` and `CODEX_RELAY_APP_SERVER_MODE=socket` as forced shared modes that fail instead of falling back
- disable fallback permanently after a shared connection initializes, so later reconnect failures never split the session into private mode
- document the platform behavior and add a minor changeset

## Why

The Unix-socket transport is the stable local control-plane path on macOS and lets terminal and mobile clients observe the same live sessions. Native Windows currently uses Codex's experimental loopback WebSocket transport, so its default remains unchanged.

## Validation

- `pnpm test` — 263 passed, 4 skipped
- `pnpm typecheck`
- `pnpm lint`
- `pnpm --filter codex-relay build`
- TypeScript no-excuse audit — no violations in changed TypeScript files
- macOS compiled-CLI smoke test — default startup served `/version`, printed `codex resume --remote unix://`, and owned the isolated Unix socket
- forced shared failure smoke test — exited 1 without falling back or opening the relay port
- default shared failure smoke test — printed the fallback event, omitted the remote attach hint, served `/version`, and ran the private stdio child
