### PR TITLE
fix: hard-refresh rewound chat history

### DIFF
--- a/.changeset/warm-cobras-refresh.md
+++ b/.changeset/warm-cobras-refresh.md
@@ -1,0 +1,6 @@
+---
+"codex-relay": patch
+"@codex-relay/mobile": patch
+---
+
+Reload the active chat from the Codex app-server when refreshing from mobile.

--- a/apps/mobile/src/components/chat/ChatScreen.tsx
+++ b/apps/mobile/src/components/chat/ChatScreen.tsx
@@ -599,11 +599,13 @@ export function ChatScreen({ initialPairingUrl }: ChatScreenProps = {}) {
   }, []);
 
   const syncThreadSnapshot = useCallback(
-    async (threadId: string, options: { setOfflineOnError?: boolean } = {}) => {
+    async (threadId: string, options: { refresh?: boolean; setOfflineOnError?: boolean } = {}) => {
       const setOfflineOnError = options.setOfflineOnError ?? true;
       setThreadMessagesLoading(threadId, true);
       try {
-        const response = await fetchThreadState(queryClient, threadId);
+        const response = await fetchThreadState(queryClient, threadId, {
+          refresh: options.refresh,
+        });
         syncPairedSessionState();
         if (chatStore$.activeThreadId.peek() !== threadId) {
           return response.thread.state;
@@ -613,6 +615,7 @@ export function ChatScreen({ initialPairingUrl }: ChatScreenProps = {}) {
           response.thread,
           response.messages,
           response.pendingInputRequests,
+          { replaceMessages: options.refresh },
         );
         await Promise.all([
           fetchQueuedInputsState(queryClient, threadId).catch(() => undefined),
@@ -653,9 +656,9 @@ export function ChatScreen({ initialPairingUrl }: ChatScreenProps = {}) {
   );
 
   const loadThread = useCallback(
-    async (threadId: string) => {
+    async (threadId: string, options: { refresh?: boolean } = {}) => {
       setActiveThread(threadId);
-      const state = await syncThreadSnapshot(threadId);
+      const state = await syncThreadSnapshot(threadId, { refresh: options.refresh });
       if (state === "running") {
         requestThreadStreamReconnect(threadId);
         return;
@@ -718,7 +721,10 @@ export function ChatScreen({ initialPairingUrl }: ChatScreenProps = {}) {
           response.threads.some((thread) => thread.id === currentActiveThreadId);
         const missingActiveThreadState =
           currentActiveThreadId && !hasCurrentActiveThread
-            ? await syncThreadSnapshot(currentActiveThreadId, { setOfflineOnError: false })
+            ? await syncThreadSnapshot(currentActiveThreadId, {
+                refresh: true,
+                setOfflineOnError: false,
+              })
             : undefined;
         if (chatStore$.activeThreadId.peek() !== currentActiveThreadId) {
           return;
@@ -734,7 +740,7 @@ export function ChatScreen({ initialPairingUrl }: ChatScreenProps = {}) {
           setActiveThread(nextActiveThreadId);
         }
         if (nextActiveThreadId && !missingActiveThreadRestored) {
-          await loadThread(nextActiveThreadId);
+          await loadThread(nextActiveThreadId, { refresh: true });
         } else if (nextActiveThreadId && missingActiveThreadState === "running") {
           requestThreadStreamReconnect(nextActiveThreadId);
         }

--- a/apps/mobile/src/lib/codex-relay-api.ts
+++ b/apps/mobile/src/lib/codex-relay-api.ts
@@ -951,8 +951,14 @@ export async function getRateLimits(): Promise<RateLimitsResponse> {
   return request(apiPaths.rateLimits, undefined, RateLimitsResponseSchema.parse);
 }
 
-export async function getThread(threadId: string): Promise<ThreadDetailResponse> {
-  return request(apiPaths.thread(threadId), undefined, ThreadDetailResponseSchema.parse);
+export async function getThread(
+  threadId: string,
+  options: { refresh?: boolean } = {},
+): Promise<ThreadDetailResponse> {
+  const path = options.refresh
+    ? `${apiPaths.thread(threadId)}?refresh=true`
+    : apiPaths.thread(threadId);
+  return request(path, undefined, ThreadDetailResponseSchema.parse);
 }
 
 export async function getThreadMessageDetail(

--- a/apps/mobile/src/lib/server-state.ts
+++ b/apps/mobile/src/lib/server-state.ts
@@ -106,18 +106,25 @@ export function fetchRateLimitsState(queryClient: QueryClient) {
   });
 }
 
-export function fetchThreadState(queryClient: QueryClient, threadId: string) {
-  return queryClient
-    .fetchQuery({
-      queryKey: serverStateKeys.thread(threadId),
-      queryFn: () => getThread(threadId),
-    })
-    .then((response) => {
-      queryClient.setQueryData<ThreadDetailResponse>(serverStateKeys.thread(threadId), (current) =>
-        mergeThreadDetailState(current, response),
-      );
-      return response;
-    });
+export async function fetchThreadState(
+  queryClient: QueryClient,
+  threadId: string,
+  options: { refresh?: boolean } = {},
+) {
+  const response = options.refresh
+    ? await getThread(threadId, { refresh: true })
+    : await queryClient.fetchQuery({
+        queryKey: serverStateKeys.thread(threadId),
+        queryFn: () => getThread(threadId),
+      });
+  setThreadDetailState(
+    queryClient,
+    response.thread,
+    response.messages,
+    response.pendingInputRequests,
+    { replaceMessages: options.refresh },
+  );
+  return response;
 }
 
 export function fetchQueuedInputsState(queryClient: QueryClient, threadId: string) {
@@ -381,6 +388,7 @@ export function setThreadDetailState(
   thread: ThreadSummary,
   messages: ChatMessage[],
   pendingInputRequests: ThreadDetailResponse["pendingInputRequests"] = [],
+  options: { replaceMessages?: boolean } = {},
 ) {
   upsertThreadState(queryClient, thread);
   const response: ThreadDetailResponse = {
@@ -389,7 +397,7 @@ export function setThreadDetailState(
     pendingInputRequests,
   };
   queryClient.setQueryData<ThreadDetailResponse>(serverStateKeys.thread(thread.id), (current) =>
-    mergeThreadDetailState(current, response),
+    options.replaceMessages ? response : mergeThreadDetailState(current, response),
   );
 }
 

--- a/packages/codex-relay/src/api-schema.ts
+++ b/packages/codex-relay/src/api-schema.ts
@@ -1190,6 +1190,11 @@ export function createOpenApiDocument() {
               required: true,
               schema: { type: "string" },
             },
+            {
+              name: "refresh",
+              in: "query",
+              schema: { type: "boolean" },
+            },
           ],
           responses: {
             "200": jsonResponse("ThreadDetailResponse"),

--- a/packages/codex-relay/src/app.ts
+++ b/packages/codex-relay/src/app.ts
@@ -372,7 +372,9 @@ export function createApp(options: AppOptions = {}) {
     const load = appServer
       .readThread(threadId, { includeTurns: true })
       .then((threadWithTurns) => {
-        const mappedThread = rememberAppServerThread(threads, threadWithTurns);
+        const mappedThread = rememberAppServerThread(threads, threadWithTurns, {
+          authoritativeMessageCount: true,
+        });
         const messages = mergeAppServerMessagesWithLocalStatus(
           mapAppServerMessages(threadWithTurns),
           messagesByThreadId.get(threadId) ?? cachedMessages,
@@ -1727,6 +1729,7 @@ export function createApp(options: AppOptions = {}) {
 
   app.get("/v1/threads/:threadId", async (c) => {
     const threadId = c.req.param("threadId");
+    const forceRefresh = c.req.query("refresh") === "true";
     const detailStartedAt = Date.now();
     relayDebugLog("thread.detail.requested", {
       threadId,
@@ -1745,31 +1748,45 @@ export function createApp(options: AppOptions = {}) {
         let messages = cachedMessages;
         let responseThread = preserveKnownRunningThreadState(mappedThread, wasKnownRunning);
 
-        const rolloutHistory = readRolloutThreadMessages(threadId, workspacePath);
-        if (rolloutHistory.messages.length > 0) {
-          messages = mergeThreadMessagePages(rolloutHistory.messages, cachedMessages);
-          responseThread = rememberRolloutThreadMessages(
-            threads,
-            responseThread,
-            messages,
-            rolloutHistory.messageCountLowerBound,
-          );
-          responseThread = preserveKnownRunningThreadState(responseThread, wasKnownRunning);
+        if (forceRefresh && responseThread.state !== "running") {
+          const threadWithTurns = await appServer.readThread(threadId, {
+            includeTurns: true,
+          });
+          responseThread = rememberAppServerThread(threads, threadWithTurns, {
+            authoritativeMessageCount: true,
+          });
+          messages = mapAppServerMessages(threadWithTurns);
           messagesByThreadId.set(threadId, messages);
           loadedMessages = true;
-        } else if (cachedMessages.length > 0) {
-          messages = dedupeThreadMessages(cachedMessages);
-          if (messages.length !== cachedMessages.length) {
+        } else {
+          const rolloutHistory = readRolloutThreadMessages(threadId, workspacePath);
+          if (rolloutHistory.messages.length > 0) {
+            messages = mergeThreadMessagePages(rolloutHistory.messages, cachedMessages);
+            responseThread = rememberRolloutThreadMessages(
+              threads,
+              responseThread,
+              messages,
+              rolloutHistory.messageCountLowerBound,
+            );
+            responseThread = preserveKnownRunningThreadState(responseThread, wasKnownRunning);
             messagesByThreadId.set(threadId, messages);
+            loadedMessages = true;
+          } else if (cachedMessages.length > 0) {
+            messages = dedupeThreadMessages(cachedMessages);
+            if (messages.length !== cachedMessages.length) {
+              messagesByThreadId.set(threadId, messages);
+            }
+            loadedMessages = true;
           }
-          loadedMessages = true;
         }
 
         if (!loadedMessages && responseThread.state !== "running") {
           const threadWithTurns = await appServer.readThread(threadId, {
             includeTurns: true,
           });
-          responseThread = rememberAppServerThread(threads, threadWithTurns);
+          responseThread = rememberAppServerThread(threads, threadWithTurns, {
+            authoritativeMessageCount: true,
+          });
           messages = mergeAppServerMessagesWithLocalStatus(
             mapAppServerMessages(threadWithTurns),
             cachedMessages,
@@ -5985,9 +6002,16 @@ function mapAppServerThread(
   });
 }
 
-function rememberAppServerThread(threads: Map<string, ThreadMetadata>, thread: AppServerThread) {
+function rememberAppServerThread(
+  threads: Map<string, ThreadMetadata>,
+  thread: AppServerThread,
+  options: { authoritativeMessageCount?: boolean } = {},
+) {
   const existingThread = threads.get(thread.id);
-  const mappedThread = mapAppServerThread(thread, existingThread?.messageCount);
+  const mappedThread = mapAppServerThread(
+    thread,
+    options.authoritativeMessageCount ? undefined : existingThread?.messageCount,
+  );
   const threadWithLocalRuntime = ThreadSummarySchema.parse({
     ...mappedThread,
     goal: existingThread?.goal ?? mappedThread.goal,

--- a/packages/codex-relay/test/app.test.ts
+++ b/packages/codex-relay/test/app.test.ts
@@ -73,6 +73,57 @@ function createMockCodex(handlers?: {
   };
 }
 
+function appServerHistoryThread(input: {
+  id: string;
+  name: string;
+  turns: Array<{
+    id: string;
+    items: Array<
+      | { id: string; type: "agentMessage"; text: string }
+      | {
+          id: string;
+          type: "userMessage";
+          content: Array<{ type: "text"; text: string; text_elements: [] }>;
+        }
+    >;
+    completedAt: number;
+    startedAt: number;
+    status: { type: string };
+  }>;
+  workspacePath: string;
+}) {
+  const now = Date.now() / 1000;
+  return {
+    id: input.id,
+    preview: input.name,
+    createdAt: now,
+    updatedAt: now,
+    status: { type: "idle" },
+    cwd: input.workspacePath,
+    source: "app",
+    modelProvider: "openai",
+    name: input.name,
+    turns: input.turns,
+  };
+}
+
+function appServerTurn(id: string, text: string, timestamp: number) {
+  return {
+    id,
+    items: [
+      {
+        id: `${id}-user`,
+        type: "userMessage" as const,
+        content: [{ type: "text" as const, text, text_elements: [] as [] }],
+      },
+      { id: `${id}-assistant`, type: "agentMessage" as const, text: `Reply: ${text}` },
+    ],
+    completedAt: timestamp + 1,
+    startedAt: timestamp,
+    status: { type: "completed" },
+  };
+}
+
 function testPairingTranscript(input: {
   approvalCode: string;
   clientEphemeralPublicKey: string;
@@ -1744,6 +1795,51 @@ describe("Codex Relay server routes", () => {
       id: "app-thread-remaining",
       title: "Remaining thread",
     });
+  });
+
+  it("refreshes an app-server thread from its current history", async () => {
+    const workspacePath = await mkdtemp(join(tmpdir(), "codex-relay-workspace-"));
+    const now = Date.now() / 1000;
+    let currentThread = appServerHistoryThread({
+      id: "app-thread-refresh",
+      name: "Refresh history",
+      turns: [
+        appServerTurn("turn-1", "First prompt", now),
+        appServerTurn("turn-2", "Second prompt", now + 10),
+      ],
+      workspacePath,
+    });
+    const appServer = {
+      onNotification() {
+        return () => undefined;
+      },
+      onRequest() {
+        return () => undefined;
+      },
+      readThread: vi.fn<() => Promise<unknown>>(async () => currentThread),
+    };
+    const app = createApp({
+      appServer: appServer as never,
+      codex: createMockCodex(),
+      workspacePath,
+    });
+
+    await app.request("/v1/threads/app-thread-refresh");
+    currentThread = appServerHistoryThread({
+      id: "app-thread-refresh",
+      name: "Refresh history",
+      turns: [appServerTurn("turn-1", "First prompt", now)],
+      workspacePath,
+    });
+    const response = await app.request("/v1/threads/app-thread-refresh?refresh=true");
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.thread.messageCount).toBe(2);
+    expect(body.messages.map((message: { id: string }) => message.id)).toEqual([
+      "turn-1-user",
+      "turn-1-assistant",
+    ]);
   });
 
   it("reads an app-server thread goal", async () => {


### PR DESCRIPTION
Fixes #37

## Summary

- make the existing **Refresh chat** action request the authoritative active-thread history from the Codex app-server
- replace Relay's cached messages instead of merging removed desktop-rewound turns back in
- add a regression test for the desktop-rewind refresh path

## Validation

- `node node_modules/vitest/vitest.mjs run packages/codex-relay/test/app.test.ts -t "refreshes an app-server thread from its current history"`
- `pnpm typecheck`