### PR TITLE
fix: isolate subagent threads from clients

### DIFF
--- a/.changeset/young-laws-shout.md
+++ b/.changeset/young-laws-shout.md
@@ -1,0 +1,5 @@
+---
+"codex-relay": patch
+---
+
+fix: isolate subagent threads from clients

--- a/packages/codex-relay/src/api-schema.ts
+++ b/packages/codex-relay/src/api-schema.ts
@@ -304,6 +304,7 @@ export const ChatMessageSchema = z.object({
 
 export const ThreadSummarySchema = z.object({
   id: z.string().min(1),
+  parentThreadId: z.string().min(1).optional(),
   title: z.string().min(1),
   createdAt: IsoDateTimeSchema,
   updatedAt: IsoDateTimeSchema,

--- a/packages/codex-relay/src/app-server.ts
+++ b/packages/codex-relay/src/app-server.ts
@@ -45,6 +45,7 @@ const sharedSocketReconnectDelaysMs = [50, 100, 250, 500, 1_000, 2_000] as const
 
 export type AppServerThread = {
   id: string;
+  parentThreadId: string | null;
   preview: string;
   createdAt: number;
   updatedAt: number;

--- a/packages/codex-relay/src/app.ts
+++ b/packages/codex-relay/src/app.ts
@@ -1654,7 +1654,9 @@ export function createApp(options: AppOptions = {}) {
       try {
         const appServerThreads = await appServer.listThreads();
         const response: ListThreadsResponse = ListThreadsResponseSchema.parse({
-          threads: appServerThreads.map((thread) => rememberAppServerThread(threads, thread)),
+          threads: appServerThreads
+            .filter((thread) => !isSubagentThread(thread))
+            .map((thread) => rememberAppServerThread(threads, thread)),
           source: "app-server",
         });
         return secureJson(c, options.pairing, secureSessionsByTokenHash, response);
@@ -1685,7 +1687,9 @@ export function createApp(options: AppOptions = {}) {
         const appServerThreads = await appServer.listThreads();
         const response: ArchiveThreadResponse = ArchiveThreadResponseSchema.parse({
           archivedThreadId: threadId,
-          threads: appServerThreads.map((thread) => rememberAppServerThread(threads, thread)),
+          threads: appServerThreads
+            .filter((thread) => !isSubagentThread(thread))
+            .map((thread) => rememberAppServerThread(threads, thread)),
           source: "app-server",
         });
         return secureJson(c, options.pairing, secureSessionsByTokenHash, response);
@@ -1732,6 +1736,15 @@ export function createApp(options: AppOptions = {}) {
       threadId,
     });
     const knownThread = threads.get(threadId);
+    if (knownThread && isSubagentThread(knownThread)) {
+      return secureJson(
+        c,
+        options.pairing,
+        secureSessionsByTokenHash,
+        apiError("not_found", `Thread ${threadId} is not known to this server.`),
+        404,
+      );
+    }
     const wasKnownRunning =
       knownThread?.state === "running" || activeAppServerTurnIdsByThreadId.has(threadId);
     if (appServer) {
@@ -1739,6 +1752,15 @@ export function createApp(options: AppOptions = {}) {
         const thread = await appServer.readThread(threadId, {
           includeTurns: false,
         });
+        if (isSubagentThread(thread)) {
+          return secureJson(
+            c,
+            options.pairing,
+            secureSessionsByTokenHash,
+            apiError("not_found", `Thread ${threadId} is not known to this server.`),
+            404,
+          );
+        }
         const mappedThread = rememberAppServerThread(threads, thread);
         const cachedMessages = messagesByThreadId.get(threadId) ?? [];
         let loadedMessages = false;
@@ -4766,7 +4788,9 @@ function createSecureSessionHandle(
 }
 
 function sortedThreads(threads: Map<string, ThreadMetadata>) {
-  return [...threads.values()].sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+  return [...threads.values()]
+    .filter((thread) => !isSubagentThread(thread))
+    .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
 }
 
 async function ensureKnownThread(input: {
@@ -4777,7 +4801,7 @@ async function ensureKnownThread(input: {
 }) {
   const knownThread = input.threads.get(input.threadId);
   if (knownThread) {
-    return knownThread;
+    return isSubagentThread(knownThread) ? undefined : knownThread;
   }
 
   if (!input.appServer) {
@@ -4788,6 +4812,9 @@ async function ensureKnownThread(input: {
     const appServerThread = await input.appServer.readThread(input.threadId, {
       includeTurns: false,
     });
+    if (isSubagentThread(appServerThread)) {
+      return undefined;
+    }
     const thread = rememberAppServerThread(input.threads, appServerThread);
     return thread;
   } catch {
@@ -5973,6 +6000,7 @@ function mapAppServerThread(
   const mappedState = mapAppServerThreadState(thread.status, thread.turns);
   return ThreadSummarySchema.parse({
     id: thread.id,
+    parentThreadId: thread.parentThreadId ?? undefined,
     title: thread.name ?? preview(thread.preview || "Untitled thread"),
     createdAt,
     updatedAt,
@@ -5996,6 +6024,10 @@ function rememberAppServerThread(threads: Map<string, ThreadMetadata>, thread: A
   });
   threads.set(threadWithLocalRuntime.id, threadWithLocalRuntime);
   return threadWithLocalRuntime;
+}
+
+function isSubagentThread(thread: { readonly parentThreadId?: string | null }) {
+  return Boolean(thread.parentThreadId);
 }
 
 function mapAppServerThreadGoal(goal: AppServerThreadGoal | null): ThreadGoal | null {
@@ -7405,7 +7437,12 @@ function observeAppServerPushNotifications(
     if (!event) {
       return;
     }
-    dispatch(event, `${event.intent}:${event.threadId}:${event.turnId ?? ""}:${request.id}`);
+    const eventId = `${event.intent}:${event.threadId}:${event.turnId ?? ""}:${request.id}`;
+    if (subagentThreadIds.has(event.threadId)) {
+      rememberEventId(eventId);
+      return;
+    }
+    dispatch(event, eventId);
   });
 }
 

--- a/packages/codex-relay/test/subagent-thread-boundaries.test.ts
+++ b/packages/codex-relay/test/subagent-thread-boundaries.test.ts
@@ -1,0 +1,224 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { ListThreadsResponseSchema } from "../src/api-schema.js";
+import {
+  CodexAppServerClient,
+  type AppServerNotification,
+  type AppServerRequest,
+} from "../src/app-server.js";
+import { createApp } from "../src/app.js";
+import type { CodexClient } from "../src/codex.js";
+import { createTursoPairingSessionStore } from "../src/pairing-store.js";
+import type { PushNotificationSender, RelayPushNotification } from "../src/push-notifications.js";
+
+function unavailableCodex(): CodexClient {
+  return {
+    resumeThread() {
+      throw new Error("Subagent input reached the legacy Codex client.");
+    },
+    startThread() {
+      throw new Error("Subagent input started a legacy Codex thread.");
+    },
+  };
+}
+
+function appServerThread(id: string, parentThreadId: string | null = null) {
+  const now = Date.now() / 1000;
+  return {
+    id,
+    parentThreadId,
+    preview: id,
+    createdAt: now,
+    updatedAt: now,
+    status: { type: "idle" },
+    cwd: "/tmp/codex-relay",
+    source: "cli",
+    modelProvider: "openai",
+    name: id,
+    turns: [],
+  };
+}
+
+function appServerWithThreads(
+  listedThreads: ReturnType<typeof appServerThread>[],
+  readableThreads = listedThreads,
+) {
+  const appServer = new CodexAppServerClient();
+  vi.spyOn(appServer, "listThreads").mockResolvedValue(listedThreads);
+  vi.spyOn(appServer, "readThread").mockImplementation(async (threadId) => {
+    const thread = readableThreads.find((candidate) => candidate.id === threadId);
+    if (!thread) {
+      throw new Error(`Unknown test thread ${threadId}.`);
+    }
+    return thread;
+  });
+  vi.spyOn(appServer, "onNotification").mockImplementation(() => () => false);
+  vi.spyOn(appServer, "onRequest").mockImplementation(() => () => false);
+  return appServer;
+}
+
+describe("subagent thread boundaries", () => {
+  it("lists parent threads without spawned subagent threads", async () => {
+    // Given
+    const parentThread = appServerThread("parent-thread");
+    const subagentThread = appServerThread("subagent-thread", parentThread.id);
+    const app = createApp({
+      appServer: appServerWithThreads([subagentThread, parentThread]),
+      codex: unavailableCodex(),
+    });
+
+    // When
+    const response = await app.request("/v1/threads");
+    const body = ListThreadsResponseSchema.parse(await response.json());
+
+    // Then
+    expect(response.status).toBe(200);
+    expect(body.threads.map((thread) => thread.id)).toEqual([parentThread.id]);
+  });
+
+  it("rejects direct reads and chat input for a spawned subagent thread", async () => {
+    // Given
+    const subagentThread = appServerThread("subagent-thread", "parent-thread");
+    const app = createApp({
+      appServer: appServerWithThreads([], [subagentThread]),
+      codex: unavailableCodex(),
+    });
+
+    // When
+    const detailResponse = await app.request(`/v1/threads/${subagentThread.id}`);
+    const runResponse = await app.request(`/v1/threads/${subagentThread.id}/runs`, {
+      method: "POST",
+      body: JSON.stringify({ prompt: "Continue directly" }),
+      headers: { "content-type": "application/json" },
+    });
+
+    // Then
+    expect(detailResponse.status).toBe(404);
+    expect(runResponse.status).toBe(404);
+  });
+
+  it("suppresses completion and action-required pushes from spawned subagents", async () => {
+    // Given
+    const sessions = await createTursoPairingSessionStore(":memory:");
+    await sessions.createSession("client-token", {
+      clientSessionId: "phone-session",
+      expiresAt: Date.now() + 60_000,
+    });
+    await sessions.upsertPushNotificationSubscription({
+      actionRequired: true,
+      clientSessionId: "phone-session",
+      expoPushToken: "ExponentPushToken[phone-token]",
+      platform: "ios",
+      turnTerminal: true,
+    });
+    const notificationHandlers = new Set<(notification: AppServerNotification) => void>();
+    const requestHandlers = new Set<(request: AppServerRequest) => void>();
+    const appServer = new CodexAppServerClient();
+    vi.spyOn(appServer, "onNotification").mockImplementation((handler) => {
+      notificationHandlers.add(handler);
+      return () => notificationHandlers.delete(handler);
+    });
+    vi.spyOn(appServer, "onRequest").mockImplementation((handler) => {
+      requestHandlers.add(handler);
+      return () => requestHandlers.delete(handler);
+    });
+    const sent: RelayPushNotification[][] = [];
+    const sender: PushNotificationSender = {
+      async send(notifications) {
+        sent.push([...notifications]);
+        return { invalidExpoPushTokens: [] };
+      },
+    };
+    createApp({
+      appServer,
+      codex: unavailableCodex(),
+      pairing: {
+        createClientToken: () => "unused-client-token",
+        hashClientToken: (token) => token,
+        sessions,
+        tokenTtlMs: 60_000,
+      },
+      pushNotificationSender: sender,
+    });
+
+    // When
+    for (const handler of notificationHandlers) {
+      handler({
+        method: "item/completed",
+        params: {
+          item: {
+            agentsStates: {},
+            id: "spawn-agent",
+            model: null,
+            prompt: null,
+            reasoningEffort: null,
+            receiverThreadIds: ["subagent-thread"],
+            senderThreadId: "parent-thread",
+            status: "completed",
+            tool: "spawnAgent",
+            type: "collabAgentToolCall",
+          },
+          threadId: "parent-thread",
+          turnId: "parent-turn",
+        },
+      });
+    }
+    for (const handler of requestHandlers) {
+      handler({
+        id: 1,
+        method: "item/tool/requestUserInput",
+        params: { threadId: "subagent-thread", turnId: "subagent-turn" },
+      });
+    }
+    for (const handler of notificationHandlers) {
+      handler({
+        method: "turn/completed",
+        params: {
+          status: "completed",
+          threadId: "subagent-thread",
+          turnId: "subagent-turn",
+        },
+      });
+    }
+    for (const handler of requestHandlers) {
+      handler({
+        id: 2,
+        method: "item/tool/requestUserInput",
+        params: { threadId: "parent-thread", turnId: "parent-turn" },
+      });
+    }
+    for (const handler of notificationHandlers) {
+      handler({
+        method: "turn/completed",
+        params: { status: "completed", threadId: "parent-thread", turnId: "parent-turn" },
+      });
+    }
+    await vi.waitFor(() =>
+      expect(sent.flat().some((notification) => notification.data.intent === "turn_terminal")).toBe(
+        true,
+      ),
+    );
+
+    // Then
+    expect(sent).toEqual([
+      [
+        expect.objectContaining({
+          data: {
+            intent: "action_required",
+            threadId: "parent-thread",
+            turnId: "parent-turn",
+          },
+        }),
+      ],
+      [
+        expect.objectContaining({
+          data: {
+            intent: "turn_terminal",
+            threadId: "parent-thread",
+            turnId: "parent-turn",
+          },
+        }),
+      ],
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

- preserve `parentThreadId` from Codex app-server and exclude spawned subagent threads from thread lists/sidebar data
- reject direct subagent thread reads and chat input with `404`
- suppress subagent `action_required` push notifications while retaining the existing terminal-notification suppression
- add regression coverage proving completion and action-required pushes are both dropped for subagents while parent-thread notifications still dispatch

## Root cause

Codex app-server identifies spawned subagent threads through `parentThreadId`, but the relay discarded that field. As a result, clients could treat subagent threads like normal conversations. Push handling also guarded terminal events through spawn receiver tracking but did not apply the same boundary to action-required requests.

## Impact

Subagent-only threads no longer appear in client thread lists, cannot be opened or messaged directly, and do not generate completion or action-required push notifications. Normal parent threads remain unchanged.

## Validation

- `pnpm --filter codex-relay exec vitest run test/subagent-thread-boundaries.test.ts` — 3 passed
- `pnpm test` — 266 passed, 4 skipped
- `pnpm typecheck`
- `pnpm lint`
- `pnpm --filter codex-relay build`
- iOS dev-client QA: refreshed the online sidebar, searched a known subagent preview and observed `No matching conversations`; normal threads remained openable
