### PR TITLE
fix: classify push notifications by thread ancestry

### DIFF
--- a/.changeset/quiet-subagent-pushes.md
+++ b/.changeset/quiet-subagent-pushes.md
@@ -1,0 +1,5 @@
+---
+"codex-relay": patch
+---
+
+Suppress subagent action-required and completion push notifications using persistent thread ancestry.

--- a/packages/codex-relay/src/app.ts
+++ b/packages/codex-relay/src/app.ts
@@ -7420,7 +7420,6 @@ function observeAppServerPushNotifications(
   dispatcher: PushNotificationDispatcher,
 ) {
   const dispatchedEventIds = new Set<string>();
-  const subagentThreadIds = new Set<string>();
   const rememberEventId = (eventId: string) => {
     if (dispatchedEventIds.size >= 1000) {
       dispatchedEventIds.clear();
@@ -7432,27 +7431,29 @@ function observeAppServerPushNotifications(
       return;
     }
     rememberEventId(eventId);
-    void dispatcher.dispatch(event).catch((error) => {
-      relayDebugLog("push_notification.dispatch_failed", {
-        error: errorMessage(error),
-        intent: event.intent,
-        threadId: event.threadId,
-        turnId: event.turnId,
+    void appServer
+      .readThread(event.threadId, { includeTurns: false })
+      .then((thread) => {
+        if (!isSubagentThread(thread)) {
+          return dispatcher.dispatch(event);
+        }
+      })
+      .catch((error) => {
+        relayDebugLog("push_notification.dispatch_failed", {
+          error: errorMessage(error),
+          intent: event.intent,
+          threadId: event.threadId,
+          turnId: event.turnId,
+        });
       });
-    });
   };
 
   appServer.onNotification((notification) => {
-    rememberSubagentThreadIds(notification, subagentThreadIds);
     const event = pushNotificationEventFromTerminalNotification(notification);
     if (!event) {
       return;
     }
     const eventId = `${event.intent}:${event.threadId}:${event.turnId ?? ""}`;
-    if (subagentThreadIds.delete(event.threadId)) {
-      rememberEventId(eventId);
-      return;
-    }
     dispatch(event, eventId);
   });
 
@@ -7462,29 +7463,8 @@ function observeAppServerPushNotifications(
       return;
     }
     const eventId = `${event.intent}:${event.threadId}:${event.turnId ?? ""}:${request.id}`;
-    if (subagentThreadIds.has(event.threadId)) {
-      rememberEventId(eventId);
-      return;
-    }
     dispatch(event, eventId);
   });
-}
-
-function rememberSubagentThreadIds(
-  notification: AppServerNotification,
-  subagentThreadIds: Set<string>,
-) {
-  const item = objectRecord(recordParams(notification)?.item);
-  if (
-    item?.type !== "collabAgentToolCall" ||
-    !["spawnAgent", "sendInput", "resumeAgent"].includes(String(item.tool))
-  ) {
-    return;
-  }
-
-  for (const threadId of stringArray(item.receiverThreadIds)) {
-    subagentThreadIds.add(threadId);
-  }
 }
 
 function pushNotificationEventFromTerminalNotification(notification: AppServerNotification) {

--- a/packages/codex-relay/test/app.test.ts
+++ b/packages/codex-relay/test/app.test.ts
@@ -1276,6 +1276,11 @@ describe("Codex Relay server routes", () => {
     const notificationHandlers = new Set<(notification: unknown) => void>();
     const requestHandlers = new Set<(request: unknown) => void>();
     const appServer = {
+      async readThread(threadId: string) {
+        return {
+          parentThreadId: threadId === "agent-thread-1" ? "thread-1" : null,
+        };
+      },
       onNotification(handler: (notification: unknown) => void) {
         notificationHandlers.add(handler);
         return () => notificationHandlers.delete(handler);

--- a/packages/codex-relay/test/subagent-thread-boundaries.test.ts
+++ b/packages/codex-relay/test/subagent-thread-boundaries.test.ts
@@ -97,7 +97,7 @@ describe("subagent thread boundaries", () => {
     expect(runResponse.status).toBe(404);
   });
 
-  it("suppresses completion and action-required pushes from spawned subagents", async () => {
+  it("suppresses subagent pushes when the observer did not see the spawn event", async () => {
     // Given
     const sessions = await createTursoPairingSessionStore(":memory:");
     await sessions.createSession("client-token", {
@@ -114,6 +114,9 @@ describe("subagent thread boundaries", () => {
     const notificationHandlers = new Set<(notification: AppServerNotification) => void>();
     const requestHandlers = new Set<(request: AppServerRequest) => void>();
     const appServer = new CodexAppServerClient();
+    vi.spyOn(appServer, "readThread").mockImplementation(async (threadId) =>
+      appServerThread(threadId, threadId === "subagent-thread" ? "parent-thread" : null),
+    );
     vi.spyOn(appServer, "onNotification").mockImplementation((handler) => {
       notificationHandlers.add(handler);
       return () => notificationHandlers.delete(handler);
@@ -142,27 +145,6 @@ describe("subagent thread boundaries", () => {
     });
 
     // When
-    for (const handler of notificationHandlers) {
-      handler({
-        method: "item/completed",
-        params: {
-          item: {
-            agentsStates: {},
-            id: "spawn-agent",
-            model: null,
-            prompt: null,
-            reasoningEffort: null,
-            receiverThreadIds: ["subagent-thread"],
-            senderThreadId: "parent-thread",
-            status: "completed",
-            tool: "spawnAgent",
-            type: "collabAgentToolCall",
-          },
-          threadId: "parent-thread",
-          turnId: "parent-turn",
-        },
-      });
-    }
     for (const handler of requestHandlers) {
       handler({
         id: 1,


### PR DESCRIPTION
## Summary

- classify action-required and terminal push candidates through app-server `thread/read`
- suppress threads with a persistent `parentThreadId` while preserving root-thread pushes
- add a patch changeset for `codex-relay`

## Root cause

Subagent suppression relied on an observer-local `Set` that was populated only when the relay observed a live `collabAgentToolCall` spawn event. A relay restart, reconnect, or any missed spawn event left the set empty, so later subagent approvals and terminal turns were treated as root-thread events and pushed to the device. The set also deleted a child after its first terminal event, so it was not a durable thread classifier.

The app-server already persists the authoritative relationship as `parentThreadId`. Push dispatch now reads that stable ancestry for both notification paths and sends only when the thread is a root thread.

## User impact

Root-thread action-required and completion pushes continue to be delivered. Subagent action-required and completion events are suppressed even when the relay observer did not witness the original spawn.

## Validation

- failing-first regression: without the spawn seed, existing code sent 4 pushes instead of the expected 2
- `pnpm test` (`267 passed`, `4 skipped`)
- `pnpm typecheck`
- `pnpm lint`
- `pnpm --filter codex-relay build`
- manual in-process notification driver observed only the 2 root-thread pushes
- live app-server `thread/read` confirmed persisted subagent ancestry through `parentThreadId`
