### PR TITLE
fix: require codex-relay 1.4.5 in app

### DIFF
--- a/.changeset/bright-relays-upgrade.md
+++ b/.changeset/bright-relays-upgrade.md
@@ -1,0 +1,5 @@
+---
+"@codex-relay/mobile": patch
+---
+
+Require codex-relay 1.4.5 or newer in the in-app relay update notice.

--- a/apps/mobile/src/lib/version-policy.ts
+++ b/apps/mobile/src/lib/version-policy.ts
@@ -2,7 +2,7 @@ import type { VersionResponse } from "codex-relay/api-schema";
 
 // Kept in the OTA-delivered JS bundle so compatibility can move with app updates.
 export const relayCompatibilityPolicy = {
-  packageVersion: "1.4.0",
+  packageVersion: "1.4.5",
 } as const;
 export const relayUpdateCommand = `npx codex-relay@${relayCompatibilityPolicy.packageVersion}`;
 


### PR DESCRIPTION
## Summary

- require `codex-relay` 1.4.5 in the OTA-delivered mobile compatibility policy
- add a patch changeset for `@codex-relay/mobile`

## Why

The current app bundle still accepts relay 1.4.0. Users on an older relay should see the existing update notice guiding them to the latest published version, 1.4.5.

## Impact

Connected relay versions below 1.4.5 now show the existing **Update relay** notice with `npx codex-relay@1.4.5`. Versions 1.4.5 and newer remain compatible.

## Validation

- `pnpm test` (275 passed, 4 skipped)
- `pnpm typecheck`
- `pnpm lint`
- `pnpm changeset status`
- direct runtime boundary check: 1.4.4 incompatible; 1.4.5 and 1.4.6 compatible
