### PR TITLE
fix: dismiss connecting banner after status check

### DIFF
--- a/.changeset/odd-poets-carry.md
+++ b/.changeset/odd-poets-carry.md
@@ -1,0 +1,5 @@
+---
+"@codex-relay/mobile": patch
+---
+
+fix: dismiss connecting banner after status check

--- a/apps/mobile/src/components/chat/ChatScreen.tsx
+++ b/apps/mobile/src/components/chat/ChatScreen.tsx
@@ -139,6 +139,7 @@ import {
 import { addWorkspacePreviewTab } from "@/state/workspace-preview-store";
 
 import { ChatControls } from "./ChatControls";
+import { runConnectionRefresh } from "./connection-refresh";
 import {
   modelForSelection,
   normalizeRuntimePreferencesForModels,
@@ -711,20 +712,23 @@ export function ChatScreen({ initialPairingUrl }: ChatScreenProps = {}) {
       try {
         await refreshSession().catch(() => false);
         syncPairedSessionState();
-        const [status, response, modelsResponse, rateLimitsResponse] = await Promise.all([
+        const [response, modelsResponse, rateLimitsResponse] = await runConnectionRefresh(
           fetchCurrentStatus(),
-          fetchThreadsState(queryClient),
-          fetchModelsState(queryClient),
-          fetchRateLimitsState(queryClient).catch(() => undefined),
-        ]);
-        applyStatusFromServer(status);
+          Promise.all([
+            fetchThreadsState(queryClient),
+            fetchModelsState(queryClient),
+            fetchRateLimitsState(queryClient).catch(() => undefined),
+          ]),
+          (status) => {
+            applyStatusFromServer(status);
+            setConnection("connected");
+          },
+        );
         setThreadsState(queryClient, response.threads, response.source);
         queryClient.setQueryData(serverStateKeys.models(), modelsResponse);
         if (rateLimitsResponse) {
           queryClient.setQueryData(serverStateKeys.rateLimits(), rateLimitsResponse);
         }
-        setConnection("connected");
-
         const currentActiveThreadId = chatStore$.activeThreadId.peek();
         const hasCurrentActiveThread =
           !!currentActiveThreadId &&

--- a/apps/mobile/src/components/chat/connection-refresh.test.ts
+++ b/apps/mobile/src/components/chat/connection-refresh.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { runConnectionRefresh } from "./connection-refresh";
+
+describe("runConnectionRefresh", () => {
+  it("marks the relay connected when status resolves while data refresh is still pending", async () => {
+    const status = { reachable: true };
+    const dataRequest = new Promise<never>(() => undefined);
+    const onStatus = vi.fn<(resolvedStatus: typeof status) => void>();
+
+    void runConnectionRefresh(Promise.resolve(status), dataRequest, onStatus);
+    await Promise.resolve();
+
+    expect(onStatus).toHaveBeenCalledWith(status);
+  });
+});

--- a/apps/mobile/src/components/chat/connection-refresh.ts
+++ b/apps/mobile/src/components/chat/connection-refresh.ts
@@ -1,0 +1,12 @@
+export async function runConnectionRefresh<Status, Data>(
+  statusRequest: Promise<Status>,
+  dataRequest: Promise<Data>,
+  onStatus: (status: Status) => void,
+) {
+  const connectedStatus = statusRequest.then((status) => {
+    onStatus(status);
+    return status;
+  });
+  const [, data] = await Promise.all([connectedStatus, dataRequest]);
+  return data;
+}


### PR DESCRIPTION
## Summary
- mark the relay connected as soon as the status request succeeds
- keep thread, model, and rate-limit refreshes concurrent without blocking the connection banner
- add a regression test for a resolved status request with pending data refreshes

## Root cause
The startup refresh attempted immediately, but `setConnection("connected")` ran only after status, threads, models, and rate limits all settled. A slow auxiliary request therefore kept the Connecting banner visible even after the relay had proven reachable.

## Validation
- `pnpm --filter @codex-relay/mobile exec vitest run` — 3 files, 4 tests passed
- `pnpm test` — 29 files passed, 1 skipped; 275 tests passed, 4 skipped
- `pnpm typecheck`
- `pnpm lint`
- iPhone 17 Pro simulator: with rate limits delayed by 8 seconds and thread listing still pending, a 235 ms status response dismissed the banner; before the patch the banner remained after 13 seconds under the same setup

## Diagnostic note
The simulator also had a persisted relay URL on port 8788 while the currently running local relay listened on 8787. That local endpoint mismatch causes a real network timeout and is separate from the fixed UI-state coupling.