### PR TITLE
fix: restore current rollout conversation history

### DIFF
--- a/.changeset/fuzzy-dodos-remember.md
+++ b/.changeset/fuzzy-dodos-remember.md
@@ -1,0 +1,5 @@
+---
+"codex-relay": patch
+---
+
+Restore conversation history for running threads recorded by current Codex versions.

--- a/packages/codex-relay/src/app.ts
+++ b/packages/codex-relay/src/app.ts
@@ -6711,6 +6711,28 @@ function rolloutRecordMessage(
     return undefined;
   }
 
+  if (record.type === "response_item" && payload.type === "message") {
+    const role = firstString(payload, ["role"]);
+    if (role !== "user" && role !== "assistant") {
+      return undefined;
+    }
+    const content = rolloutResponseItemMessageContent(payload, role);
+    if (!content) {
+      return undefined;
+    }
+    const messageParts = role === "assistant" ? agentMessageParts(content) : undefined;
+    return ChatMessageSchema.parse({
+      id: firstString(payload, ["id"]) ?? `${messageKey}:${role}`,
+      threadId,
+      role,
+      content: messageParts?.content ?? content,
+      details: messageParts?.details,
+      createdAt: timestamp,
+      state: "completed",
+      turnId,
+    });
+  }
+
   if (record.type === "event_msg" && payload.type === "user_message") {
     const content = firstString(payload, ["message"]);
     if (!content) {
@@ -6813,6 +6835,26 @@ function rolloutRecordMessage(
   }
 
   return undefined;
+}
+
+function rolloutResponseItemMessageContent(
+  payload: Record<string, unknown>,
+  role: "assistant" | "user",
+) {
+  if (!Array.isArray(payload.content)) {
+    return undefined;
+  }
+  const expectedType = role === "user" ? "input_text" : "output_text";
+  const text = payload.content.flatMap((item) => {
+    if (!item || typeof item !== "object") {
+      return [];
+    }
+    const contentItem = item as Record<string, unknown>;
+    return contentItem.type === expectedType && typeof contentItem.text === "string"
+      ? [contentItem.text]
+      : [];
+  });
+  return text.length > 0 ? text.join("\n\n") : undefined;
 }
 
 function rolloutUserMessageDetails(payload: Record<string, unknown>) {
@@ -7064,7 +7106,8 @@ function isRolloutMessageLine(line: string) {
         line.includes('"type":"exec_command_end"') ||
         line.includes('"type":"mcp_tool_call_end"'))) ||
     (line.includes('"type":"response_item"') &&
-      (line.includes('"type":"custom_tool_call"') ||
+      (line.includes('"type":"message"') ||
+        line.includes('"type":"custom_tool_call"') ||
         line.includes('"type":"custom_tool_call_output"')))
   );
 }

--- a/packages/codex-relay/test/app.test.ts
+++ b/packages/codex-relay/test/app.test.ts
@@ -7177,6 +7177,113 @@ describe("Codex Relay server routes", () => {
     }
   });
 
+  it("loads current response-item rollout messages while a thread is running", async () => {
+    const workspacePath = await mkdtemp(join(tmpdir(), "codex-relay-workspace-"));
+    const codexHome = await mkdtemp(join(tmpdir(), "codex-relay-home-"));
+    const sessionsDir = join(codexHome, "sessions", "2026", "08", "15");
+    await mkdir(sessionsDir, { recursive: true });
+    const threadId = "app-thread-running-response-items";
+    await writeFile(
+      join(sessionsDir, `rollout-2026-08-15T00-00-00-${threadId}.jsonl`),
+      [
+        JSON.stringify({
+          payload: {
+            content: [{ text: "current rollout prompt", type: "input_text" }],
+            id: "msg-user-current",
+            role: "user",
+            type: "message",
+          },
+          timestamp: "2026-08-15T00:00:00.000Z",
+          type: "response_item",
+        }),
+        JSON.stringify({
+          payload: {
+            content: [{ text: "internal instructions", type: "input_text" }],
+            id: "msg-developer-current",
+            role: "developer",
+            type: "message",
+          },
+          timestamp: "2026-08-15T00:00:01.000Z",
+          type: "response_item",
+        }),
+        JSON.stringify({
+          payload: {
+            content: [{ text: "current rollout answer", type: "output_text" }],
+            id: "msg-assistant-current",
+            phase: "final_answer",
+            role: "assistant",
+            type: "message",
+          },
+          timestamp: "2026-08-15T00:00:02.000Z",
+          type: "response_item",
+        }),
+      ].join("\n"),
+    );
+    const previousCodexHome = process.env.CODEX_HOME;
+    process.env.CODEX_HOME = codexHome;
+    const now = Date.now() / 1000;
+    const runningThread = {
+      id: threadId,
+      createdAt: now,
+      cwd: workspacePath,
+      modelProvider: "gpt-5.5",
+      name: "Running response-item thread",
+      preview: "Running response-item thread",
+      source: "app",
+      status: { type: "active" },
+      updatedAt: now,
+    };
+    const readThread = vi.fn<
+      (_threadId: string, options?: { includeTurns?: boolean }) => Promise<unknown>
+    >(async (_threadId, options) => {
+      if (options?.includeTurns === true) {
+        return new Promise(() => undefined);
+      }
+      return runningThread;
+    });
+    const appServer = {
+      listThreads: vi.fn<() => Promise<unknown[]>>(async () => [runningThread]),
+      onNotification() {
+        return () => undefined;
+      },
+      onRequest() {
+        return () => undefined;
+      },
+      readThread,
+    };
+    const app = createApp({
+      appServer: appServer as never,
+      codex: createMockCodex(),
+      workspacePath,
+    });
+
+    try {
+      const response = await app.request(`/v1/threads/${threadId}`);
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(readThread).toHaveBeenCalledTimes(1);
+      expect(readThread).toHaveBeenCalledWith(threadId, { includeTurns: false });
+      expect(body.thread.state).toBe("running");
+      expect(
+        body.messages.map((message: { content: string; id: string; role: string }) => ({
+          content: message.content,
+          id: message.id,
+          role: message.role,
+        })),
+      ).toEqual([
+        { content: "current rollout prompt", id: "msg-user-current", role: "user" },
+        {
+          content: "current rollout answer",
+          id: "msg-assistant-current",
+          role: "assistant",
+        },
+      ]);
+    } finally {
+      process.env.CODEX_HOME = previousCodexHome;
+    }
+  });
+
   it("loads the full readable rollout conversation when tool events are newest", async () => {
     const workspacePath = await mkdtemp(join(tmpdir(), "codex-relay-workspace-"));
     const codexHome = await mkdtemp(join(tmpdir(), "codex-relay-home-"));


### PR DESCRIPTION
## Summary

- Read current Codex response-item message records from rollout history.
- Preserve stable message IDs while excluding developer instructions.
- Hydrate running threads immediately without waiting for a full app-server history read.

## Root cause

Codex CLI 0.145.0 records visible user and assistant messages as response_item records. The Relay rollout reader only recognised the older event_msg message records, so it found no local history. For a running thread, Relay then returned an empty cache and started the app-server includeTurns read in the background while the mobile client attached only to new stream events.

## Impact

Opening an existing running conversation from mobile now shows its prior conversation immediately. Existing event_msg rollout history remains supported.

## Validation

- pnpm test: 291 passed, 4 skipped
- pnpm typecheck
- pnpm lint
- Focused live-rollout probe: 44 messages recovered from the active 8.2 MB rollout without app-server history