### PR TITLE
fix: align thread history with Codex 0.149

### DIFF
--- a/.changeset/calm-threads-align.md
+++ b/.changeset/calm-threads-align.md
@@ -1,5 +1,6 @@
 ---
 "codex-relay": patch
+"@codex-relay/mobile": patch
 ---
 
-Keep relay and mobile thread history consistent with Codex 0.149 app-server and SDK behavior.
+Keep relay and mobile thread history consistent with Codex 0.149 app-server and SDK behavior, and require the compatible relay release from the app.

--- a/.changeset/calm-threads-align.md
+++ b/.changeset/calm-threads-align.md
@@ -1,0 +1,5 @@
+---
+"codex-relay": patch
+---
+
+Keep relay and mobile thread history consistent with Codex 0.149 app-server and SDK behavior.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -188,7 +188,7 @@ jobs:
           git push --force-with-lease origin HEAD:refs/heads/changeset-release/npm-main
 
       - name: Update mobile release branch
-        if: steps.mobile-release-plan.outputs.deploy == 'true'
+        if: steps.mobile-release-plan.outputs.deploy == 'true' && steps.mobile-release-plan.outputs.relay-package-version == ''
         run: |
           git switch --detach "$GITHUB_SHA"
           git switch --create changeset-release/mobile-main "$GITHUB_SHA"
@@ -220,7 +220,7 @@ jobs:
                 ].join("\n"),
               });
             }
-            if (process.env.MOBILE_RELEASE_VERSION) {
+            if (process.env.MOBILE_RELEASE_VERSION && !process.env.RELAY_RELEASE_VERSION) {
               releases.push({
                 branch: "changeset-release/mobile-main",
                 title: `chore: release @codex-relay/mobile@${process.env.MOBILE_RELEASE_VERSION} (app-version ${process.env.IOS_APP_VERSION})`,

--- a/.github/workflows/update-codex-sdk.yml
+++ b/.github/workflows/update-codex-sdk.yml
@@ -39,15 +39,16 @@ jobs:
         run: |
           current_version="$(node -p 'require("./packages/codex-relay/package.json").dependencies["@openai/codex-sdk"]')"
           latest_version="$(pnpm view @openai/codex-sdk@latest version)"
+          codex_cli_version="$(pnpm view "@openai/codex-sdk@$latest_version" dependencies.@openai/codex)"
 
           if [[ "$current_version" == "$latest_version" ]]; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          pnpm --filter codex-relay add "@openai/codex-sdk@$latest_version" --save-exact --lockfile-only
+          pnpm --filter codex-relay add "@openai/codex@$codex_cli_version" "@openai/codex-sdk@$latest_version" --save-exact --lockfile-only
           changeset_path=".changeset/update-codex-sdk-$latest_version.md"
-          printf -- '---\n"codex-relay": patch\n---\n\nUpdate `@openai/codex-sdk` to `%s`.\n' "$latest_version" > "$changeset_path"
+          printf -- '---\n"codex-relay": patch\n---\n\nUpdate `@openai/codex-sdk` to `%s` and pin its Codex CLI `%s` for app-server compatibility.\n' "$latest_version" "$codex_cli_version" > "$changeset_path"
           echo "changed=true" >> "$GITHUB_OUTPUT"
           echo "changeset=$changeset_path" >> "$GITHUB_OUTPUT"
           echo "version=$latest_version" >> "$GITHUB_OUTPUT"

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -18,6 +18,7 @@ import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { KeyboardProvider } from "react-native-keyboard-controller";
 
 import { AnimatedSplashOverlay } from "@/components/animated-icon";
+import { RelayVersionGate } from "@/components/RelayVersionGate";
 import { useInitialPushNotificationRegistration } from "@/hooks/use-initial-push-notification-registration";
 import { addHotUpdaterLog, formatHotUpdaterProgress } from "@/lib/hot-updater-logs";
 import {
@@ -191,41 +192,43 @@ function TabLayout() {
           <KeyboardProvider>
             <BottomSheetModalProvider>
               <AnimatedSplashOverlay />
-              <Stack
-                screenOptions={{
-                  contentStyle: {
-                    backgroundColor: "#191919",
-                  },
-                  headerShown: false,
-                }}
-              >
-                <Stack.Screen name="(drawer)" />
-                <Stack.Screen name="pair" />
-                <Stack.Screen
-                  name="image-viewer"
-                  options={{
+              <RelayVersionGate>
+                <Stack
+                  screenOptions={{
                     contentStyle: {
-                      backgroundColor: "#050505",
+                      backgroundColor: "#191919",
                     },
-                    gestureEnabled: true,
-                    presentation: "modal",
+                    headerShown: false,
                   }}
-                />
-                <Stack.Screen
-                  name="settings"
-                  options={{
-                    animation: "slide_from_right",
-                    title: "Settings",
-                  }}
-                />
-                <Stack.Screen
-                  name="workspace-file-editor"
-                  options={{
-                    animation: "slide_from_right",
-                    title: "File Editor",
-                  }}
-                />
-              </Stack>
+                >
+                  <Stack.Screen name="(drawer)" />
+                  <Stack.Screen name="pair" />
+                  <Stack.Screen
+                    name="image-viewer"
+                    options={{
+                      contentStyle: {
+                        backgroundColor: "#050505",
+                      },
+                      gestureEnabled: true,
+                      presentation: "modal",
+                    }}
+                  />
+                  <Stack.Screen
+                    name="settings"
+                    options={{
+                      animation: "slide_from_right",
+                      title: "Settings",
+                    }}
+                  />
+                  <Stack.Screen
+                    name="workspace-file-editor"
+                    options={{
+                      animation: "slide_from_right",
+                      title: "File Editor",
+                    }}
+                  />
+                </Stack>
+              </RelayVersionGate>
               <PortalHost />
             </BottomSheetModalProvider>
           </KeyboardProvider>

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -178,7 +178,7 @@ function TabLayout() {
       client={queryClient}
       onSuccess={() => restoreChatStoreFromQueryCache(queryClient)}
       persistOptions={{
-        buster: "codex-relay-server-state-v1",
+        buster: "codex-relay-server-state-v2",
         dehydrateOptions: {
           shouldDehydrateQuery: shouldPersistQuery,
         },

--- a/apps/mobile/src/components/RelayVersionGate.tsx
+++ b/apps/mobile/src/components/RelayVersionGate.tsx
@@ -1,0 +1,150 @@
+import { useSelector } from "@legendapp/state/react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { router } from "expo-router";
+import { type ReactNode, useMemo } from "react";
+import { ActivityIndicator, ScrollView, View } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { StyleSheet } from "react-native-unistyles";
+
+import { ThemedText } from "@/components/themed-text";
+import { Button } from "@/components/ui/button";
+import { CopyableCommand } from "@/components/ui/copyable-command";
+import { Colors, Spacing } from "@/constants/theme";
+import { hasCodexRelaySession, signOutCodexRelaySession } from "@/lib/codex-relay-api";
+import { clearServerState, serverStateKeys, serverStateQueryFns } from "@/lib/server-state";
+import { evaluateRelayVersion } from "@/lib/version-policy";
+import { chatStore$, resetChatSessionState } from "@/state/chat-store";
+
+export function RelayVersionGate({ children }: { children: ReactNode }) {
+  const queryClient = useQueryClient();
+  const hasPairedSession = useSelector(() => chatStore$.hasPairedSession.get());
+  const shouldVerifyRelay = hasPairedSession || hasCodexRelaySession();
+  const versionQuery = useQuery({
+    queryKey: serverStateKeys.version(),
+    queryFn: serverStateQueryFns.version,
+    enabled: shouldVerifyRelay,
+    retry: false,
+    staleTime: 0,
+  });
+  const compatibility = useMemo(
+    () => evaluateRelayVersion(versionQuery.data, versionQuery.error),
+    [versionQuery.data, versionQuery.error],
+  );
+
+  if (!shouldVerifyRelay || compatibility?.compatible) {
+    return children;
+  }
+
+  function useAnotherRelay() {
+    signOutCodexRelaySession();
+    clearServerState(queryClient);
+    resetChatSessionState();
+    router.replace("/");
+  }
+
+  if (!compatibility) {
+    return <RelayVersionChecking />;
+  }
+
+  return (
+    <View style={styles.safeArea}>
+      <ScrollView
+        contentContainerStyle={styles.scrollContent}
+        contentInsetAdjustmentBehavior="automatic"
+        keyboardShouldPersistTaps="handled"
+      >
+        <View accessibilityRole="alert" style={styles.card}>
+          <ThemedText type="subtitle" style={styles.title}>
+            Update codex-relay
+          </ThemedText>
+          <ThemedText type="small" themeColor="textSecondary">
+            {compatibility.reason} Update the relay on your computer, then check again.
+          </ThemedText>
+          <ThemedText type="code">Current: {compatibility.current}</ThemedText>
+          <ThemedText type="code">Required: {compatibility.required}</ThemedText>
+          <View style={styles.commandBlock}>
+            <ThemedText type="smallBold">Run on your computer</ThemedText>
+            <CopyableCommand
+              command={compatibility.updateCommand}
+              copyAccessibilityLabel="Copy relay update command"
+            />
+          </View>
+          <Button
+            accessibilityRole="button"
+            accessibilityLabel="Check relay version again"
+            className="h-11 rounded-lg"
+            disabled={versionQuery.isFetching}
+            onPress={() => void versionQuery.refetch()}
+          >
+            {versionQuery.isFetching ? <ActivityIndicator color="#161616" size="small" /> : null}
+            <ThemedText type="smallBold" style={styles.primaryActionText}>
+              {versionQuery.isFetching ? "Checking" : "Check again"}
+            </ThemedText>
+          </Button>
+          <Button
+            accessibilityRole="button"
+            accessibilityLabel="Use another relay"
+            className="h-10 rounded-lg"
+            onPress={useAnotherRelay}
+            variant="ghost"
+          >
+            <ThemedText type="smallBold" themeColor="textSecondary">
+              Use another relay
+            </ThemedText>
+          </Button>
+        </View>
+      </ScrollView>
+    </View>
+  );
+}
+
+function RelayVersionChecking() {
+  return (
+    <SafeAreaView edges={["top", "bottom", "left", "right"]} style={styles.safeArea}>
+      <View accessible accessibilityLabel="Checking codex-relay version" style={styles.checking}>
+        <ActivityIndicator color={Colors.dark.text} size="small" />
+        <ThemedText type="smallBold">Checking codex-relay</ThemedText>
+      </View>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safeArea: {
+    backgroundColor: "#191919",
+    flex: 1,
+  },
+  scrollContent: {
+    alignItems: "center",
+    flexGrow: 1,
+    justifyContent: "center",
+    padding: Spacing.four,
+  },
+  card: {
+    backgroundColor: "#222323",
+    borderColor: "rgba(255, 255, 255, 0.1)",
+    borderRadius: 16,
+    borderCurve: "continuous",
+    borderWidth: 1,
+    gap: Spacing.three,
+    maxWidth: 520,
+    padding: Spacing.four,
+    width: "100%",
+  },
+  title: {
+    fontSize: 28,
+    lineHeight: 34,
+  },
+  commandBlock: {
+    gap: Spacing.two,
+  },
+  primaryActionText: {
+    color: "#161616",
+  },
+  checking: {
+    alignItems: "center",
+    flex: 1,
+    gap: Spacing.three,
+    justifyContent: "center",
+  },
+});

--- a/apps/mobile/src/components/chat/ChatScreen.tsx
+++ b/apps/mobile/src/components/chat/ChatScreen.tsx
@@ -93,6 +93,7 @@ import {
   fetchThreadQueryState,
   fetchThreadState,
   fetchThreadsState,
+  fetchVersionState,
   fetchWorkspaceChangesState,
   optimisticallySteerQueuedInputState,
   removePendingInputRequestState,
@@ -119,6 +120,7 @@ import {
   reconcileThreadRunEventAfterTerminal,
 } from "@/lib/thread-run-stream";
 import { readCachedWorkspaceRuntimePreferences } from "@/lib/workspace-runtime-preferences-cache";
+import { requireCompatibleRelayVersion } from "@/lib/version-policy";
 import {
   appendComposerAttachments,
   chatStore$,
@@ -712,6 +714,7 @@ export function ChatScreen({ initialPairingUrl }: ChatScreenProps = {}) {
       syncPairedSessionState();
       setServerUrl(getCodexRelayServerUrl());
       try {
+        requireCompatibleRelayVersion(await fetchVersionState(queryClient));
         await refreshSession().catch(() => false);
         syncPairedSessionState();
         const [response, modelsResponse, rateLimitsResponse] = await runConnectionRefresh(

--- a/apps/mobile/src/components/chat/ChatScreen.tsx
+++ b/apps/mobile/src/components/chat/ChatScreen.tsx
@@ -9,6 +9,7 @@ import type {
   ReasoningEffort,
   RuntimeMode,
   RuntimePreferences,
+  StreamThreadRunEvent,
   ThreadCollaborationMode,
   ThreadSummary,
   WebPreviewTarget,
@@ -54,6 +55,7 @@ import { CopyableCommand } from "@/components/ui/copyable-command";
 import { AppToast } from "@/components/ui/toast";
 import { Colors, Fonts, Spacing } from "@/constants/theme";
 import { activeThreadAfterRefresh } from "@/lib/active-thread-selection";
+import { consumeHydratedDefaultThread } from "@/lib/server-state-hydration";
 import {
   getCodexRelayServerUrl,
   hasCodexRelaySession,
@@ -88,6 +90,7 @@ import {
   fetchRateLimitsState,
   fetchStatusState,
   fetchThreadGoalState,
+  fetchThreadQueryState,
   fetchThreadState,
   fetchThreadsState,
   fetchWorkspaceChangesState,
@@ -110,7 +113,11 @@ import {
   updateRuntimePreferencesServerState,
 } from "@/lib/server-state";
 import { recordSuccessfulAiConversationForReviewPrompt } from "@/lib/store-review-prompt";
-import { completeThreadRunSession, handleThreadRunStreamEvent } from "@/lib/thread-run-stream";
+import {
+  completeThreadRunSession,
+  handleThreadRunStreamEvent,
+  reconcileThreadRunEventAfterTerminal,
+} from "@/lib/thread-run-stream";
 import { readCachedWorkspaceRuntimePreferences } from "@/lib/workspace-runtime-preferences-cache";
 import {
   appendComposerAttachments,
@@ -445,7 +452,7 @@ export function ChatScreen({ initialPairingUrl }: ChatScreenProps = {}) {
     queryKey: activeThreadId
       ? serverStateKeys.thread(activeThreadId)
       : [...serverStateKeys.threads(), "__inactive__", "detail"],
-    queryFn: ({ queryKey }) => serverStateQueryFns.thread(String(queryKey[3] ?? "")),
+    queryFn: ({ queryKey }) => fetchThreadQueryState(queryClient, String(queryKey[3] ?? "")),
     enabled: Boolean(activeThreadId),
   });
   const queuedInputsQuery = useQuery({
@@ -623,13 +630,6 @@ export function ChatScreen({ initialPairingUrl }: ChatScreenProps = {}) {
         if (chatStore$.activeThreadId.peek() !== threadId) {
           return response.thread.state;
         }
-        setThreadDetailState(
-          queryClient,
-          response.thread,
-          response.messages,
-          response.pendingInputRequests,
-          { replaceMessages: options.refresh },
-        );
         await Promise.all([
           fetchQueuedInputsState(queryClient, threadId).catch(() => undefined),
           fetchContextWindowState(queryClient, threadId).catch(() => undefined),
@@ -732,6 +732,7 @@ export function ChatScreen({ initialPairingUrl }: ChatScreenProps = {}) {
           queryClient.setQueryData(serverStateKeys.rateLimits(), rateLimitsResponse);
         }
         const currentActiveThreadId = chatStore$.activeThreadId.peek();
+        const preferFirstThread = consumeHydratedDefaultThread(currentActiveThreadId);
         const hasCurrentActiveThread =
           !!currentActiveThreadId &&
           response.threads.some((thread) => thread.id === currentActiveThreadId);
@@ -749,6 +750,7 @@ export function ChatScreen({ initialPairingUrl }: ChatScreenProps = {}) {
         const nextActiveThreadId = activeThreadAfterRefresh({
           currentActiveThreadId,
           missingActiveThreadRestored,
+          preferFirstThread,
           threads: response.threads,
         });
 
@@ -861,6 +863,7 @@ export function ChatScreen({ initialPairingUrl }: ChatScreenProps = {}) {
       streamGenerationRef.current = streamGeneration;
       let receivedStreamEvent = false;
       let sawTerminalStreamEvent = false;
+      let terminalStreamEvent: StreamThreadRunEvent | undefined;
       markStreamActivity();
       setThreadRunningState(queryClient, threadId, true);
       setConnection("connected");
@@ -874,9 +877,16 @@ export function ChatScreen({ initialPairingUrl }: ChatScreenProps = {}) {
             if (streamGeneration !== streamGenerationRef.current) {
               return;
             }
+            const reconciledEvent = reconcileThreadRunEventAfterTerminal(
+              event,
+              terminalStreamEvent,
+            );
+            if (!reconciledEvent) {
+              return;
+            }
             markStreamActivity();
             receivedStreamEvent = true;
-            handleThreadRunStreamEvent(event, {
+            handleThreadRunStreamEvent(reconciledEvent, {
               fallbackThreadId: threadId,
               applyEvent: (streamEvent) => {
                 applyStreamEventToServerState(queryClient, streamEvent);
@@ -888,7 +898,11 @@ export function ChatScreen({ initialPairingUrl }: ChatScreenProps = {}) {
                 }));
               },
               onTerminal(terminalThreadId, terminalEvent) {
+                if (sawTerminalStreamEvent) {
+                  return;
+                }
                 sawTerminalStreamEvent = true;
+                terminalStreamEvent = terminalEvent;
                 completeThreadRunSession({
                   threadId: terminalThreadId,
                   clearQueuedPrompts,
@@ -1558,6 +1572,7 @@ export function ChatScreen({ initialPairingUrl }: ChatScreenProps = {}) {
       streamGenerationRef.current = streamGeneration;
       let receivedStreamEvent = false;
       let sawTerminalStreamEvent = false;
+      let terminalStreamEvent: StreamThreadRunEvent | undefined;
       markStreamActivity();
       const restorePrompt = () => {
         if (!input.restoreDraftOnFailure) {
@@ -1584,12 +1599,22 @@ export function ChatScreen({ initialPairingUrl }: ChatScreenProps = {}) {
             if (streamGeneration !== streamGenerationRef.current) {
               return;
             }
+            const reconciledEvent = reconcileThreadRunEventAfterTerminal(
+              event,
+              terminalStreamEvent,
+            );
+            if (!reconciledEvent) {
+              return;
+            }
             markStreamActivity();
             receivedStreamEvent = true;
-            if (event.type === "thread.state.changed" && event.thread.state === "running") {
-              markQueuedPromptStarted(runThreadId, event.thread.lastPrompt);
+            if (
+              reconciledEvent.type === "thread.state.changed" &&
+              reconciledEvent.thread.state === "running"
+            ) {
+              markQueuedPromptStarted(runThreadId, reconciledEvent.thread.lastPrompt);
             }
-            handleThreadRunStreamEvent(event, {
+            handleThreadRunStreamEvent(reconciledEvent, {
               fallbackThreadId: runThreadId,
               applyEvent: (streamEvent) => {
                 applyStreamEventToServerState(queryClient, streamEvent);
@@ -1601,7 +1626,11 @@ export function ChatScreen({ initialPairingUrl }: ChatScreenProps = {}) {
                 }));
               },
               onTerminal(terminalThreadId, terminalEvent) {
+                if (sawTerminalStreamEvent) {
+                  return;
+                }
                 sawTerminalStreamEvent = true;
+                terminalStreamEvent = terminalEvent;
                 completeThreadRunSession({
                   threadId: terminalThreadId,
                   clearQueuedPrompts,

--- a/apps/mobile/src/components/chat/ThreadDrawerContent.tsx
+++ b/apps/mobile/src/components/chat/ThreadDrawerContent.tsx
@@ -614,10 +614,12 @@ function useThreadDrawerActions({
   workspacePath: string | undefined;
 }) {
   const pendingDrawerActionTaskRef = useRef<{ cancel: () => void } | undefined>(undefined);
+  const threadSelectionGenerationRef = useRef(0);
 
   useEffect(
     () => () => {
       pendingDrawerActionTaskRef.current?.cancel();
+      threadSelectionGenerationRef.current += 1;
     },
     [],
   );
@@ -627,24 +629,24 @@ function useThreadDrawerActions({
   }, []);
 
   const activateSelectedThread = useCallback(
-    async (threadId: string) => {
+    async (threadId: string, selectionGeneration: number) => {
       const selectedThread = threadsById[threadId];
       setActiveThread(threadId);
       setThreadMessagesLoading(threadId, true);
       try {
         const response = await fetchThreadState(queryClient, threadId);
-        setThreadDetailState(
-          queryClient,
-          response.thread,
-          response.messages,
-          response.pendingInputRequests,
-        );
+        if (selectionGeneration !== threadSelectionGenerationRef.current) {
+          return;
+        }
         setActiveThread(response.thread.id);
         if (response.thread.state === "running") {
           requestThreadStreamReconnect(threadId);
         }
         setConnection("connected");
       } catch (caught) {
+        if (selectionGeneration !== threadSelectionGenerationRef.current) {
+          return;
+        }
         syncPairedSessionState();
         setThreadRunningState(queryClient, selectedThread?.id ?? threadId, false);
         setConnection(
@@ -663,11 +665,13 @@ function useThreadDrawerActions({
       hapticSelection();
       navigation.closeDrawer();
       pendingDrawerActionTaskRef.current?.cancel();
+      const selectionGeneration = threadSelectionGenerationRef.current + 1;
+      threadSelectionGenerationRef.current = selectionGeneration;
       if (chatStore$.activeThreadId.peek() === threadId) {
         return;
       }
       pendingDrawerActionTaskRef.current = InteractionManager.runAfterInteractions(() => {
-        void activateSelectedThread(threadId);
+        void activateSelectedThread(threadId, selectionGeneration);
       });
     },
     [activateSelectedThread, navigation],

--- a/apps/mobile/src/lib/active-thread-selection.ts
+++ b/apps/mobile/src/lib/active-thread-selection.ts
@@ -3,12 +3,17 @@ import type { ThreadSummary } from "codex-relay/api-schema";
 export function activeThreadAfterRefresh({
   currentActiveThreadId,
   missingActiveThreadRestored,
+  preferFirstThread = false,
   threads,
 }: {
   currentActiveThreadId: string | undefined;
   missingActiveThreadRestored: boolean;
+  preferFirstThread?: boolean;
   threads: ThreadSummary[];
 }) {
+  if (preferFirstThread && threads[0]) {
+    return threads[0].id;
+  }
   if (
     currentActiveThreadId &&
     (missingActiveThreadRestored || threads.some((thread) => thread.id === currentActiveThreadId))

--- a/apps/mobile/src/lib/server-state-hydration.ts
+++ b/apps/mobile/src/lib/server-state-hydration.ts
@@ -4,9 +4,18 @@ import type { QueryClient } from "@tanstack/react-query";
 import { serverStateKeys } from "@/lib/server-state";
 import { chatStore$, setActiveThread } from "@/state/chat-store";
 
+let hydratedDefaultThreadId: string | undefined;
+
 export function restoreChatStoreFromQueryCache(queryClient: QueryClient) {
   const threads = queryClient.getQueryData<ListThreadsResponse>(serverStateKeys.threads());
   if (!chatStore$.activeThreadId.peek() && threads?.threads[0]) {
+    hydratedDefaultThreadId = threads.threads[0].id;
     setActiveThread(threads.threads[0].id);
   }
+}
+
+export function consumeHydratedDefaultThread(threadId: string | undefined) {
+  const wasHydratedDefault = Boolean(threadId && threadId === hydratedDefaultThreadId);
+  hydratedDefaultThreadId = undefined;
+  return wasHydratedDefault;
 }

--- a/apps/mobile/src/lib/server-state-messages.ts
+++ b/apps/mobile/src/lib/server-state-messages.ts
@@ -47,12 +47,13 @@ export function mergeThreadDetailState(
   current: ThreadDetailResponse | undefined,
   response: ThreadDetailResponse,
 ) {
-  if (!current || current.thread.id !== response.thread.id || current.messages.length === 0) {
+  if (!current || current.thread.id !== response.thread.id) {
     return response;
   }
   const messages = mergeMessages(current.messages, response.messages);
   return {
     ...response,
+    thread: preferredThreadSnapshot(current.thread, response.thread),
     messages,
   };
 }
@@ -60,7 +61,12 @@ export function mergeThreadDetailState(
 export function upsertMessage(messages: ChatMessage[], message: ChatMessage) {
   const existingIndex = messages.findIndex((candidate) => candidate.id === message.id);
   if (existingIndex !== -1) {
-    return messages.map((candidate) => (candidate.id === message.id ? message : candidate));
+    return messages.map((candidate) =>
+      candidate.id === message.id ? preferredMessageSnapshot(candidate, message) : candidate,
+    );
+  }
+  if (messages.some((candidate) => replacementMessageId(candidate) === message.id)) {
+    return messages;
   }
   const replacementId = replacementMessageId(message);
   const replacementIndex = replacementId
@@ -87,7 +93,7 @@ export function upsertMessage(messages: ChatMessage[], message: ChatMessage) {
       index === messages.length - 1 ? message : candidate,
     );
   }
-  return [...messages, message];
+  return sortMessagesByCreation([...messages, message]);
 }
 
 function optimisticSteeringMessageId(inputId: string) {
@@ -95,13 +101,26 @@ function optimisticSteeringMessageId(inputId: string) {
 }
 
 function mergeMessages(baseMessages: ChatMessage[], incomingMessages: ChatMessage[]) {
-  const incomingById = new Map(incomingMessages.map((message) => [message.id, message]));
+  const replacedMessageIds = new Set(
+    [...baseMessages, ...incomingMessages]
+      .map(replacementMessageId)
+      .filter((id): id is string => id !== undefined),
+  );
+  const baseById = new Map(baseMessages.map((message) => [message.id, message]));
+  const incomingById = new Map(
+    incomingMessages.map((message) => [
+      message.id,
+      baseById.has(message.id)
+        ? preferredMessageSnapshot(baseById.get(message.id)!, message)
+        : message,
+    ]),
+  );
   const indexesById = new Map<string, number>();
   const seenIds = new Set<string>();
   const messages: ChatMessage[] = [];
   for (const candidate of [...baseMessages, ...incomingMessages]) {
     const message = incomingById.get(candidate.id) ?? candidate;
-    if (seenIds.has(message.id)) {
+    if (seenIds.has(message.id) || replacedMessageIds.has(message.id)) {
       continue;
     }
     const replacementId = replacementMessageId(message);
@@ -129,7 +148,39 @@ function mergeMessages(baseMessages: ChatMessage[], incomingMessages: ChatMessag
     indexesById.set(message.id, messages.length);
     messages.push(message);
   }
-  return messages;
+  return sortMessagesByCreation(messages);
+}
+
+function preferredMessageSnapshot(current: ChatMessage, incoming: ChatMessage) {
+  const currentUpdatedAt = current.updatedAt ?? current.createdAt;
+  const incomingUpdatedAt = incoming.updatedAt ?? incoming.createdAt;
+  if (currentUpdatedAt !== incomingUpdatedAt) {
+    return currentUpdatedAt > incomingUpdatedAt ? current : incoming;
+  }
+  if (current.state === "completed" && incoming.state !== "completed") {
+    return current;
+  }
+  return incoming;
+}
+
+export function preferredThreadSnapshot(current: ThreadSummary, incoming: ThreadSummary) {
+  if (current.updatedAt !== incoming.updatedAt) {
+    return current.updatedAt > incoming.updatedAt ? current : incoming;
+  }
+  if (current.state !== "running" && incoming.state === "running") {
+    return current;
+  }
+  return incoming;
+}
+
+function sortMessagesByCreation(messages: ChatMessage[]) {
+  return messages
+    .map((message, index) => ({ index, message }))
+    .sort(
+      (left, right) =>
+        left.message.createdAt.localeCompare(right.message.createdAt) || left.index - right.index,
+    )
+    .map(({ message }) => message);
 }
 
 function isDuplicateOptimisticQueuedMessage(

--- a/apps/mobile/src/lib/server-state.ts
+++ b/apps/mobile/src/lib/server-state.ts
@@ -111,6 +111,13 @@ export function fetchRateLimitsState(queryClient: QueryClient) {
   });
 }
 
+export function fetchVersionState(queryClient: QueryClient) {
+  return queryClient.fetchQuery({
+    queryKey: serverStateKeys.version(),
+    queryFn: getVersion,
+  });
+}
+
 export async function fetchThreadState(
   queryClient: QueryClient,
   threadId: string,

--- a/apps/mobile/src/lib/server-state.ts
+++ b/apps/mobile/src/lib/server-state.ts
@@ -53,6 +53,7 @@ import {
 import {
   appendOptimisticSteeringMessageToDetail,
   mergeThreadDetailState,
+  preferredThreadSnapshot,
   upsertMessage,
 } from "./server-state-messages";
 
@@ -115,20 +116,31 @@ export async function fetchThreadState(
   threadId: string,
   options: { refresh?: boolean } = {},
 ) {
-  const response = options.refresh
-    ? await getThread(threadId, { refresh: true })
-    : await queryClient.fetchQuery({
-        queryKey: serverStateKeys.thread(threadId),
-        queryFn: () => getThread(threadId),
-      });
-  setThreadDetailState(
-    queryClient,
-    response.thread,
-    response.messages,
-    response.pendingInputRequests,
-    { replaceMessages: options.refresh },
+  if (options.refresh) {
+    const response = await getThread(threadId, { refresh: true });
+    setThreadDetailState(
+      queryClient,
+      response.thread,
+      response.messages,
+      response.pendingInputRequests,
+      { replaceMessages: true },
+    );
+    return response;
+  }
+  return queryClient.fetchQuery({
+    queryKey: serverStateKeys.thread(threadId),
+    queryFn: () => fetchThreadQueryState(queryClient, threadId),
+  });
+}
+
+export async function fetchThreadQueryState(queryClient: QueryClient, threadId: string) {
+  const response = await getThread(threadId);
+  const merged = mergeThreadDetailState(
+    queryClient.getQueryData<ThreadDetailResponse>(serverStateKeys.thread(threadId)),
+    response,
   );
-  return response;
+  upsertThreadState(queryClient, merged.thread);
+  return merged;
 }
 
 export function fetchQueuedInputsState(queryClient: QueryClient, threadId: string) {
@@ -404,13 +416,16 @@ export function setThreadsState(
 export function upsertThreadState(queryClient: QueryClient, thread: ThreadSummary) {
   queryClient.setQueryData<ListThreadsResponse>(serverStateKeys.threads(), (current) => {
     const threads = current?.threads ?? [];
+    const existing = threads.find((candidate) => candidate.id === thread.id);
     return {
       source: current?.source ?? "memory",
-      threads: sortThreads(upsertById(threads, thread)),
+      threads: sortThreads(
+        upsertById(threads, existing ? preferredThreadSnapshot(existing, thread) : thread),
+      ),
     };
   });
   queryClient.setQueryData<ThreadDetailResponse>(serverStateKeys.thread(thread.id), (current) =>
-    current ? { ...current, thread } : current,
+    current ? { ...current, thread: preferredThreadSnapshot(current.thread, thread) } : current,
   );
 }
 
@@ -721,12 +736,14 @@ function appendMessageDeltaState(
       ...current,
       messages: current.messages.map((message) =>
         message.id === messageId
-          ? {
-              ...message,
-              content: `${message.content}${normalizeStreamDelta(message.content, delta)}`,
-              state: "streaming",
-              updatedAt: new Date().toISOString(),
-            }
+          ? message.state === "completed"
+            ? message
+            : {
+                ...message,
+                content: `${message.content}${normalizeStreamDelta(message.content, delta)}`,
+                state: "streaming",
+                updatedAt: new Date().toISOString(),
+              }
           : message,
       ),
     };

--- a/apps/mobile/src/lib/thread-run-stream.ts
+++ b/apps/mobile/src/lib/thread-run-stream.ts
@@ -136,6 +136,53 @@ export function isSuccessfulThreadRunTerminalEvent(event: StreamThreadRunEvent) 
   return event.type === "thread.state.changed" && event.thread.state === "completed";
 }
 
+export function reconcileThreadRunEventAfterTerminal(
+  event: StreamThreadRunEvent,
+  terminalEvent: StreamThreadRunEvent | undefined,
+): StreamThreadRunEvent | undefined {
+  if (!terminalEvent) {
+    return event;
+  }
+
+  const terminalState =
+    terminalEvent.type === "thread.state.changed"
+      ? {
+          lastError: terminalEvent.thread.lastError,
+          state: terminalEvent.thread.state,
+        }
+      : terminalEvent.type === "thread.error"
+        ? {
+            lastError: terminalEvent.thread?.lastError ?? terminalEvent.error.message,
+            state: terminalEvent.thread?.state ?? ("failed" as const),
+          }
+        : undefined;
+  switch (event.type) {
+    case "thread.message.created":
+    case "thread.message.completed":
+      return terminalState
+        ? {
+            ...event,
+            thread: {
+              ...event.thread,
+              ...terminalState,
+            },
+          }
+        : event;
+    case "thread.error":
+      return terminalState && event.thread
+        ? {
+            ...event,
+            thread: {
+              ...event.thread,
+              ...terminalState,
+            },
+          }
+        : event;
+    default:
+      return undefined;
+  }
+}
+
 export function handleThreadRunStreamEvent(
   event: StreamThreadRunEvent,
   options: HandleThreadRunStreamEventOptions,

--- a/apps/mobile/src/lib/version-policy.test.ts
+++ b/apps/mobile/src/lib/version-policy.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import relayPackage from "codex-relay/package.json";
+
+import {
+  evaluateRelayVersion,
+  relayCompatibilityPolicy,
+  relayUpdateCommand,
+  requireCompatibleRelayVersion,
+} from "./version-policy";
+
+function relayVersion(packageVersion: string) {
+  return {
+    ok: true as const,
+    packageName: "codex-relay" as const,
+    packageVersion,
+    service: "codex-relay-server" as const,
+  };
+}
+
+function previousPatchVersion(version: string) {
+  const [major, minor, patch] = version.split(".").map(Number);
+  return `${major}.${minor}.${patch - 1}`;
+}
+
+function nextPatchVersion(version: string) {
+  const [major, minor, patch] = version.split(".").map(Number);
+  return `${major}.${minor}.${patch + 1}`;
+}
+
+function nextMajorVersion(version: string) {
+  const [major] = version.split(".").map(Number);
+  return `${major + 1}.0.0`;
+}
+
+describe("relay version policy", () => {
+  it("requires the relay package version bundled with the mobile release", () => {
+    const requiredVersion = relayPackage.version;
+    const olderVersion = previousPatchVersion(requiredVersion);
+
+    expect(relayCompatibilityPolicy.packageVersion).toBe(requiredVersion);
+    expect(relayUpdateCommand).toBe("npx codex-relay@latest");
+    expect(evaluateRelayVersion(relayVersion(olderVersion), undefined)).toMatchObject({
+      compatible: false,
+      current: olderVersion,
+      required: requiredVersion,
+    });
+  });
+
+  it("accepts the required release and newer same-major releases", () => {
+    const newerVersion = nextPatchVersion(relayPackage.version);
+
+    expect(requireCompatibleRelayVersion(relayVersion(relayPackage.version))).toMatchObject({
+      compatible: true,
+      current: relayPackage.version,
+    });
+    expect(requireCompatibleRelayVersion(relayVersion(newerVersion))).toMatchObject({
+      compatible: true,
+      current: newerVersion,
+    });
+  });
+
+  it("rejects prereleases, unparseable versions, and unsupported major releases", () => {
+    for (const packageVersion of [
+      `${relayPackage.version}-beta.1`,
+      "latest",
+      nextMajorVersion(relayPackage.version),
+    ]) {
+      expect(() => requireCompatibleRelayVersion(relayVersion(packageVersion))).toThrow(
+        "Run npx codex-relay@latest.",
+      );
+    }
+  });
+
+  it("blocks use when the app cannot verify the relay version", () => {
+    expect(evaluateRelayVersion(undefined, new Error("offline"))).toMatchObject({
+      compatible: false,
+      current: "Unavailable",
+      required: relayPackage.version,
+    });
+  });
+});

--- a/apps/mobile/src/lib/version-policy.ts
+++ b/apps/mobile/src/lib/version-policy.ts
@@ -1,10 +1,11 @@
 import type { VersionResponse } from "codex-relay/api-schema";
+import relayPackage from "codex-relay/package.json";
 
 // Kept in the OTA-delivered JS bundle so compatibility can move with app updates.
 export const relayCompatibilityPolicy = {
-  packageVersion: "1.4.5",
+  packageVersion: relayPackage.version,
 } as const;
-export const relayUpdateCommand = `npx codex-relay@${relayCompatibilityPolicy.packageVersion}`;
+export const relayUpdateCommand = "npx codex-relay@latest";
 
 export type RelayVersionCompatibility =
   | {
@@ -64,6 +65,16 @@ export function evaluateRelayVersion(
     serverPackageVersion: version.packageVersion,
     updateCommand: relayUpdateCommand,
   };
+}
+
+export function requireCompatibleRelayVersion(version: VersionResponse) {
+  const compatibility = evaluateRelayVersion(version, undefined);
+  if (!compatibility?.compatible) {
+    throw new Error(
+      `${compatibility?.reason ?? "The relay version could not be verified."} Run ${relayUpdateCommand}.`,
+    );
+  }
+  return compatibility;
 }
 
 function compareRelayVersions(current: string, required: string) {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "version-packages:npm": "node scripts/version-packages.mjs npm",
     "version-packages:mobile": "node scripts/version-packages.mjs mobile",
     "release": "changeset publish",
-    "test:release": "node --test scripts/mobile-release-version.test.mjs && pnpm --filter @codex-relay/mobile exec vitest run src/lib/mobile-release-version.test.ts",
+    "test:release": "node --test scripts/mobile-release-version.test.mjs && pnpm --filter @codex-relay/mobile exec vitest run src/lib/mobile-release-version.test.ts src/lib/version-policy.test.ts",
     "typecheck": "pnpm -r typecheck",
     "test": "pnpm --filter codex-relay test",
     "test:live:mobile-stream": "CODEX_RELAY_LIVE_APP_SERVER_TEST=1 pnpm --filter codex-relay test -- live-mobile-stream-contract.test.ts"

--- a/packages/codex-relay/package.json
+++ b/packages/codex-relay/package.json
@@ -49,6 +49,7 @@
     "@noble/ciphers": "2.2.0",
     "@noble/curves": "2.2.0",
     "@noble/hashes": "2.2.0",
+    "@openai/codex": "0.149.1",
     "@openai/codex-sdk": "0.149.1",
     "base64-js": "1.5.1",
     "commander": "^14.0.3",

--- a/packages/codex-relay/src/api-schema.ts
+++ b/packages/codex-relay/src/api-schema.ts
@@ -284,6 +284,7 @@ export const PendingInputRequestQuestionSchema = z.object({
 
 export const PendingInputRequestSchema = z.object({
   id: z.string().min(1),
+  isBlocking: z.boolean().default(true),
   questions: z.array(PendingInputRequestQuestionSchema),
   threadId: z.string().min(1),
   turnId: z.string().optional(),

--- a/packages/codex-relay/src/app-server.ts
+++ b/packages/codex-relay/src/app-server.ts
@@ -17,7 +17,7 @@ import {
 import { relayDebugLog } from "./debug-log.js";
 
 type JsonRpcServerMessage = {
-  id?: number;
+  id?: number | string;
   method?: string;
   params?: unknown;
   result?: unknown;
@@ -49,17 +49,21 @@ export type AppServerThread = {
   preview: string;
   createdAt: number;
   updatedAt: number;
+  recencyAt?: number | null;
   status: unknown;
   cwd: string;
   source: string;
   modelProvider: string;
   name: string | null;
+  historyMode?: "legacy" | "paginated";
+  path?: string | null;
   turns?: AppServerTurn[];
 };
 
 export type AppServerTurn = {
   id: string;
   items: AppServerThreadItem[];
+  itemsView?: "notLoaded" | "summary" | "full";
   status: unknown;
   error?: {
     codexErrorInfo?: string;
@@ -67,6 +71,7 @@ export type AppServerTurn = {
   } | null;
   startedAt: number | null;
   completedAt: number | null;
+  durationMs?: number | null;
 };
 
 export type AppServerTextElement = {
@@ -92,9 +97,10 @@ export type AppServerThreadItem =
   | {
       type: "userMessage";
       id: string;
+      clientId?: string | null;
       content: AppServerUserInput[];
     }
-  | { type: "agentMessage"; id: string; text: string }
+  | { type: "agentMessage"; delivery?: "async" | null; id: string; text: string }
   | {
       type: "plan";
       id: string;
@@ -184,7 +190,7 @@ export type AppServerThreadGoal = {
 };
 
 export type AppServerRequest = {
-  id: number;
+  id: number | string;
   method: string;
   params: unknown;
 };
@@ -197,11 +203,10 @@ export type AppServerNotification = {
 export type AppServerThreadStartParams = {
   approvalPolicy?: string | null;
   cwd?: string | null;
-  experimentalRawEvents: boolean;
   model?: string | null;
-  persistExtendedHistory: boolean;
   sandbox?: string | null;
   serviceTier?: string | null;
+  threadSource?: string | null;
 };
 
 export type AppServerThreadResumeParams = {
@@ -209,7 +214,6 @@ export type AppServerThreadResumeParams = {
   cwd?: string | null;
   excludeTurns?: boolean;
   model?: string | null;
-  persistExtendedHistory: boolean;
   sandbox?: string | null;
   serviceTier?: string | null;
   threadId: string;
@@ -217,6 +221,7 @@ export type AppServerThreadResumeParams = {
 
 export type AppServerTurnStartParams = {
   approvalPolicy?: string | null;
+  clientUserMessageId?: string | null;
   collaborationMode?: {
     mode: "default" | "plan";
     settings: {
@@ -253,6 +258,11 @@ export type AppServerThreadRollbackParams = {
   threadId: string;
 };
 
+export type AppServerThreadRevertParams = {
+  beforeTurnId: string;
+  threadId: string;
+};
+
 export type AppServerThreadGoalGetParams = {
   threadId: string;
 };
@@ -283,6 +293,9 @@ export class CodexAppServerClient {
   private sharedReconnectEnabled = false;
   private sharedServer: ChildProcessWithoutNullStreams | undefined;
   private socket: WebSocket | undefined;
+  private activeTurnIdsByThreadId = new Map<string, string>();
+  private terminalTurnIdsByThreadId = new Map<string, string>();
+  private subscribedThreadIds = new Set<string>();
   private readonly onStartupFallback: ((error: Error) => void) | undefined;
   private readonly startSharedServer: () => Promise<ChildProcessWithoutNullStreams>;
 
@@ -303,14 +316,30 @@ export class CodexAppServerClient {
   }
 
   async listThreads(limit = 80) {
-    const response = await this.request<{ data: AppServerThread[] }>("thread/list", {
-      limit,
-      sortKey: "updated_at",
-      sortDirection: "desc",
-      sourceKinds: [],
-      archived: false,
-    });
-    return response.data;
+    const threads: AppServerThread[] = [];
+    const seenCursors = new Set<string>();
+    let cursor: string | undefined;
+    do {
+      const response = await this.request<{
+        data: AppServerThread[];
+        nextCursor?: string | null;
+      }>("thread/list", {
+        archived: false,
+        cursor,
+        limit,
+        sortDirection: "desc",
+        sortKey: "recency_at",
+        sourceKinds: ["cli", "vscode", "exec", "appServer"],
+      });
+      threads.push(...response.data);
+      const nextCursor = response.nextCursor ?? undefined;
+      if (!nextCursor || seenCursors.has(nextCursor)) {
+        break;
+      }
+      seenCursors.add(nextCursor);
+      cursor = nextCursor;
+    } while (cursor);
+    return threads;
   }
 
   async readThread(threadId: string, options: { includeTurns?: boolean } = {}) {
@@ -335,16 +364,34 @@ export class CodexAppServerClient {
 
   async startThread(params: AppServerThreadStartParams) {
     const response = await this.request<{ thread: AppServerThread }>("thread/start", params);
+    this.subscribedThreadIds.add(response.thread.id);
     return response.thread;
   }
 
   async resumeThread(params: AppServerThreadResumeParams) {
-    const response = await this.request<{ thread: AppServerThread }>("thread/resume", params);
+    const response = await this.request<{
+      initialTurnsPage?: { data: AppServerTurn[] } | null;
+      thread: AppServerThread;
+    }>(
+      "thread/resume",
+      params.excludeTurns
+        ? {
+            ...params,
+            initialTurnsPage: { itemsView: "summary", limit: 1, sortDirection: "desc" },
+          }
+        : params,
+    );
+    this.subscribedThreadIds.add(response.thread.id);
+    this.rememberActiveTurn({
+      ...response.thread,
+      turns: response.initialTurnsPage?.data ?? response.thread.turns,
+    });
     return response.thread;
   }
 
   async startTurn(params: AppServerTurnStartParams) {
     const response = await this.request<{ turn: AppServerTurn }>("turn/start", params);
+    this.rememberTurn(params.threadId, response.turn);
     return response.turn;
   }
 
@@ -354,6 +401,9 @@ export class CodexAppServerClient {
 
   async archiveThread(params: AppServerThreadArchiveParams) {
     await this.request("thread/archive", params);
+    this.subscribedThreadIds.delete(params.threadId);
+    this.activeTurnIdsByThreadId.delete(params.threadId);
+    this.terminalTurnIdsByThreadId.delete(params.threadId);
   }
 
   async setThreadName(params: AppServerThreadNameSetParams) {
@@ -362,6 +412,11 @@ export class CodexAppServerClient {
 
   async rollbackThread(params: AppServerThreadRollbackParams) {
     const response = await this.request<{ thread: AppServerThread }>("thread/rollback", params);
+    return response.thread;
+  }
+
+  async revertThread(params: AppServerThreadRevertParams) {
+    const response = await this.request<{ thread: AppServerThread }>("thread/revert", params);
     return response.thread;
   }
 
@@ -392,11 +447,11 @@ export class CodexAppServerClient {
     return () => this.requestHandlers.delete(handler);
   }
 
-  async respondToRequest(id: number, result: unknown) {
+  async respondToRequest(id: number | string, result: unknown) {
     await this.writeJson({ id, result });
   }
 
-  async rejectRequest(id: number, code: number, message: string) {
+  async rejectRequest(id: number | string, code: number, message: string) {
     await this.writeJson({ id, error: { code, message } });
   }
 
@@ -412,6 +467,9 @@ export class CodexAppServerClient {
     this.stopStdioCodexAppServer();
     this.stopSharedCodexAppServer();
     this.initialized = undefined;
+    this.activeTurnIdsByThreadId.clear();
+    this.terminalTurnIdsByThreadId.clear();
+    this.subscribedThreadIds.clear();
   }
 
   private async request<T>(method: string, params: unknown): Promise<T> {
@@ -489,8 +547,113 @@ export class CodexAppServerClient {
       },
       capabilities: {
         experimentalApi: true,
+        requestAttestation: false,
       },
     });
+    await this.writeJson({ method: "initialized" });
+    for (const threadId of this.subscribedThreadIds) {
+      try {
+        const disconnectedTurnId = this.activeTurnIdsByThreadId.get(threadId);
+        const response = await this.requestRaw<{
+          initialTurnsPage?: { data: AppServerTurn[] } | null;
+          thread: AppServerThread;
+        }>("thread/resume", {
+          excludeTurns: true,
+          initialTurnsPage: { itemsView: "summary", limit: 1, sortDirection: "desc" },
+          threadId,
+        });
+        this.reconcileResumedThread(
+          {
+            ...response.thread,
+            turns: response.initialTurnsPage?.data ?? response.thread.turns,
+          },
+          disconnectedTurnId,
+        );
+      } catch (error) {
+        relayDebugLog("app_server.thread.resubscribe_failed", {
+          message: error instanceof Error ? error.message : String(error),
+          threadId,
+        });
+      }
+    }
+  }
+
+  private reconcileResumedThread(thread: AppServerThread, disconnectedTurnId?: string) {
+    if (disconnectedTurnId) {
+      const disconnectedTurn = thread.turns?.find((turn) => turn.id === disconnectedTurnId);
+      if (disconnectedTurn && !isAppServerTurnInProgress(disconnectedTurn)) {
+        this.dispatchNotification({
+          method: "turn/completed",
+          params: { threadId: thread.id, turn: disconnectedTurn },
+        });
+      } else {
+        this.dispatchNotification({
+          method: "thread/status/changed",
+          params: { status: thread.status, threadId: thread.id },
+        });
+      }
+    }
+    this.rememberActiveTurn(thread);
+  }
+
+  private rememberActiveTurn(thread: AppServerThread) {
+    const activeTurn = [...(thread.turns ?? [])]
+      .reverse()
+      .find((turn) => isAppServerTurnInProgress(turn));
+    if (activeTurn && this.terminalTurnIdsByThreadId.get(thread.id) !== activeTurn.id) {
+      this.activeTurnIdsByThreadId.set(thread.id, activeTurn.id);
+      this.terminalTurnIdsByThreadId.delete(thread.id);
+    } else {
+      this.activeTurnIdsByThreadId.delete(thread.id);
+    }
+  }
+
+  private rememberTurn(threadId: string, turn: AppServerTurn) {
+    if (isAppServerTurnInProgress(turn)) {
+      if (this.terminalTurnIdsByThreadId.get(threadId) !== turn.id) {
+        this.activeTurnIdsByThreadId.set(threadId, turn.id);
+        this.terminalTurnIdsByThreadId.delete(threadId);
+      }
+    } else if (this.activeTurnIdsByThreadId.get(threadId) === turn.id) {
+      this.activeTurnIdsByThreadId.delete(threadId);
+    }
+  }
+
+  private dispatchNotification(notification: AppServerNotification) {
+    const params = notification.params;
+    const record = params && typeof params === "object" ? (params as Record<string, unknown>) : {};
+    const threadId = typeof record.threadId === "string" ? record.threadId : undefined;
+    const turn =
+      record.turn && typeof record.turn === "object"
+        ? (record.turn as Partial<AppServerTurn>)
+        : undefined;
+    const turnId =
+      typeof record.turnId === "string"
+        ? record.turnId
+        : typeof turn?.id === "string"
+          ? turn.id
+          : undefined;
+    if (notification.method === "turn/started" && threadId && turnId) {
+      if (this.terminalTurnIdsByThreadId.get(threadId) !== turnId) {
+        this.activeTurnIdsByThreadId.set(threadId, turnId);
+        this.terminalTurnIdsByThreadId.delete(threadId);
+      }
+    } else if (
+      ["turn/completed", "turn/failed", "turn/aborted", "turn/cancelled"].includes(
+        notification.method,
+      ) &&
+      threadId
+    ) {
+      if (turnId) {
+        this.terminalTurnIdsByThreadId.set(threadId, turnId);
+      }
+      if (!turnId || this.activeTurnIdsByThreadId.get(threadId) === turnId) {
+        this.activeTurnIdsByThreadId.delete(threadId);
+      }
+    }
+    for (const handler of this.notificationHandlers) {
+      handler(notification);
+    }
   }
 
   private startStdioCodexAppServer() {
@@ -740,7 +903,10 @@ export class CodexAppServerClient {
       return;
     }
 
-    if (typeof message.method === "string" && typeof message.id === "number") {
+    if (
+      typeof message.method === "string" &&
+      (typeof message.id === "number" || typeof message.id === "string")
+    ) {
       debugAppServer("server-request", message.method, message.id);
       const request = { id: message.id, method: message.method, params: message.params };
       if (this.requestHandlers.size === 0) {
@@ -756,9 +922,7 @@ export class CodexAppServerClient {
     if (typeof message.method === "string") {
       debugAppServer("notification", message.method);
       const notification = { method: message.method, params: message.params };
-      for (const handler of this.notificationHandlers) {
-        handler(notification);
-      }
+      this.dispatchNotification(notification);
       return;
     }
 
@@ -894,11 +1058,31 @@ function sharedCodexAppServerSocketPath() {
   );
 }
 
+function isAppServerTurnInProgress(turn: AppServerTurn) {
+  if (turn.completedAt !== null && turn.completedAt !== undefined) {
+    return false;
+  }
+  const status =
+    typeof turn.status === "string"
+      ? turn.status
+      : turn.status && typeof turn.status === "object" && "type" in turn.status
+        ? String(turn.status.type)
+        : "";
+  return ["active", "inprogress", "running"].includes(
+    status.toLowerCase().replace(/[^a-z0-9]/g, ""),
+  );
+}
+
 function asError(error: unknown) {
   return error instanceof Error ? error : new Error(String(error));
 }
 
-function debugAppServer(kind: string, method: string | undefined, id?: number, detail?: string) {
+function debugAppServer(
+  kind: string,
+  method: string | undefined,
+  id?: number | string,
+  detail?: string,
+) {
   if (process.env.CODEX_RELAY_DEBUG_APP_SERVER !== "1") {
     return;
   }

--- a/packages/codex-relay/src/app.ts
+++ b/packages/codex-relay/src/app.ts
@@ -110,7 +110,17 @@ import { Hono } from "hono";
 import { cors } from "hono/cors";
 import { execFile } from "node:child_process";
 import { createHash, randomUUID } from "node:crypto";
-import { existsSync, mkdirSync, readFileSync, readdirSync, statSync, writeFileSync } from "node:fs";
+import {
+  closeSync,
+  existsSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  readSync,
+  readdirSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
 import { mkdir, open, readFile, readdir, stat, writeFile } from "node:fs/promises";
 import { createRequire } from "node:module";
 import { homedir, hostname } from "node:os";
@@ -251,8 +261,9 @@ type PendingApproval = {
     | "mcpElicitation";
   messageId?: string;
   method: string;
+  isBlocking?: boolean;
   questions?: PendingInputRequestQuestion[];
-  requestId: number;
+  requestId: number | string;
   threadId: string;
   turnId?: string;
 };
@@ -332,14 +343,69 @@ export function createApp(options: AppOptions = {}) {
   const appServerMutationTails = new Map<string, Promise<void>>();
   const workspaceTerminalSessions = new Map<string, WorkspaceTerminalSession>();
   const activeAppServerTurnIdsByThreadId = new Map<string, string>();
+  const appServerHistoryGenerationsByThreadId = new Map<string, number>();
   const appServerHistoryLoadsByThreadId = new Map<string, Promise<void>>();
+  const appServerRolloutPathsByThreadId = new Map<string, string>();
   const steeringThreads = new Set<string>();
   const secureSessionsByTokenHash = new Map<string, SecureSession>();
   const activeStreamControllers = new Map<
     ReadableStreamDefaultController<Uint8Array>,
     () => void
   >();
-  const threadOptions = { workingDirectory: workspacePath };
+  const threadOptions = { threadSource: "codex-relay", workingDirectory: workspacePath };
+  const advanceAppServerHistoryGeneration = (threadId: string) => {
+    appServerHistoryGenerationsByThreadId.set(
+      threadId,
+      (appServerHistoryGenerationsByThreadId.get(threadId) ?? 0) + 1,
+    );
+  };
+  const invalidateAppServerHistory = (threadId: string) => {
+    advanceAppServerHistoryGeneration(threadId);
+    appServerHistoryLoadsByThreadId.delete(threadId);
+    appServerRolloutPathsByThreadId.delete(threadId);
+    messagesByThreadId.delete(threadId);
+  };
+  if (appServer && typeof appServer.onNotification === "function") {
+    appServer.onNotification((notification) => {
+      const params = recordParams(notification);
+      const threadId = firstString(params, ["threadId"]);
+      if (!threadId) {
+        return;
+      }
+      if (notification.method === "thread/reverted") {
+        invalidateAppServerHistory(threadId);
+        return;
+      }
+      if (notification.method === "item/completed") {
+        advanceAppServerHistoryGeneration(threadId);
+        const item = params?.item;
+        if (
+          item &&
+          typeof item === "object" &&
+          (item as { type?: unknown }).type !== "userMessage"
+        ) {
+          upsertAppServerItemMessage(
+            messagesByThreadId,
+            threadId,
+            firstString(params, ["turnId"]),
+            item as AppServerThreadItem,
+          );
+        }
+        return;
+      }
+      if (notification.method === "turn/completed") {
+        advanceAppServerHistoryGeneration(threadId);
+        const turn = appServerTurnFromParams(params);
+        if (turn) {
+          for (const item of turn.items) {
+            if (item.type !== "userMessage") {
+              upsertAppServerItemMessage(messagesByThreadId, threadId, turn.id, item);
+            }
+          }
+        }
+      }
+    });
+  }
   function runThreadOperation<T>(threadId: string, operation: () => Promise<T>) {
     const previous = threadOperationTails.get(threadId) ?? Promise.resolve();
     const result = previous.then(operation, operation);
@@ -384,6 +450,7 @@ export function createApp(options: AppOptions = {}) {
       return;
     }
     const startedAt = Date.now();
+    const historyGeneration = appServerHistoryGenerationsByThreadId.get(threadId) ?? 0;
     relayDebugLog("thread.detail.history.background_started", {
       cachedMessageCount: cachedMessages.length,
       threadId,
@@ -391,13 +458,18 @@ export function createApp(options: AppOptions = {}) {
     const load = appServer
       .readThread(threadId, { includeTurns: true })
       .then((threadWithTurns) => {
+        if ((appServerHistoryGenerationsByThreadId.get(threadId) ?? 0) !== historyGeneration) {
+          return;
+        }
+        const hasCompleteHistory = appServerThreadHasCompleteHistory(threadWithTurns);
         const mappedThread = rememberAppServerThread(threads, threadWithTurns, {
-          authoritativeMessageCount: true,
+          authoritativeMessageCount: hasCompleteHistory,
         });
-        const messages = mergeAppServerMessagesWithLocalStatus(
-          mapAppServerMessages(threadWithTurns),
-          messagesByThreadId.get(threadId) ?? cachedMessages,
-        );
+        const appMessages = mapAppServerMessages(threadWithTurns);
+        const localMessages = messagesByThreadId.get(threadId) ?? cachedMessages;
+        const messages = hasCompleteHistory
+          ? mergeAppServerMessagesWithLocalStatus(appMessages, localMessages)
+          : mergeThreadMessagePages(appMessages, localMessages);
         messagesByThreadId.set(threadId, messages);
         relayDebugLog("thread.detail.history.background_completed", {
           durationMs: Date.now() - startedAt,
@@ -414,7 +486,9 @@ export function createApp(options: AppOptions = {}) {
         });
       })
       .finally(() => {
-        appServerHistoryLoadsByThreadId.delete(threadId);
+        if (appServerHistoryLoadsByThreadId.get(threadId) === load) {
+          appServerHistoryLoadsByThreadId.delete(threadId);
+        }
       });
     appServerHistoryLoadsByThreadId.set(threadId, load);
   };
@@ -1884,10 +1958,31 @@ export function createApp(options: AppOptions = {}) {
             );
           }
 
-          const rolledBackThread = await appServer.rollbackThread({
-            threadId,
-            numTurns: turns.length - turnIndex,
-          });
+          let rolledBackThread: AppServerThread;
+          if (
+            threadBeforeRewind.historyMode === "paginated" &&
+            typeof appServer.revertThread === "function"
+          ) {
+            try {
+              rolledBackThread = await appServer.revertThread({
+                beforeTurnId: parsed.data.turnId,
+                threadId,
+              });
+            } catch (error) {
+              if (!/method not found|unsupported|-32601/i.test(errorMessage(error))) {
+                throw error;
+              }
+              rolledBackThread = await appServer.rollbackThread({
+                threadId,
+                numTurns: turns.length - turnIndex,
+              });
+            }
+          } else {
+            rolledBackThread = await appServer.rollbackThread({
+              threadId,
+              numTurns: turns.length - turnIndex,
+            });
+          }
           const threadWithTurns =
             rolledBackThread.turns === undefined
               ? await appServer.readThread(threadId, { includeTurns: true })
@@ -1896,6 +1991,7 @@ export function createApp(options: AppOptions = {}) {
             authoritativeMessageCount: true,
           });
           const messages = mapAppServerMessages(threadWithTurns);
+          invalidateAppServerHistory(threadId);
           messagesByThreadId.set(threadId, messages);
           liveThreads.delete(threadId);
           activeAppServerTurnIdsByThreadId.delete(threadId);
@@ -1961,7 +2057,15 @@ export function createApp(options: AppOptions = {}) {
           );
         }
         const mappedThread = rememberAppServerThread(threads, thread);
-        const cachedMessages = messagesByThreadId.get(threadId) ?? [];
+        let cachedMessages = messagesByThreadId.get(threadId) ?? [];
+        if (thread.path) {
+          const previousRolloutPath = appServerRolloutPathsByThreadId.get(threadId);
+          if (previousRolloutPath && previousRolloutPath !== thread.path) {
+            invalidateAppServerHistory(threadId);
+            cachedMessages = [];
+          }
+          appServerRolloutPathsByThreadId.set(threadId, thread.path);
+        }
         let loadedMessages = false;
         let messages = cachedMessages;
         let responseThread = preserveKnownRunningThreadState(mappedThread, wasKnownRunning);
@@ -1970,14 +2074,25 @@ export function createApp(options: AppOptions = {}) {
           const threadWithTurns = await appServer.readThread(threadId, {
             includeTurns: true,
           });
+          const hasCompleteHistory = appServerThreadHasCompleteHistory(threadWithTurns);
           responseThread = rememberAppServerThread(threads, threadWithTurns, {
-            authoritativeMessageCount: true,
+            authoritativeMessageCount: hasCompleteHistory,
           });
-          messages = mapAppServerMessages(threadWithTurns);
+          const appMessages = mapAppServerMessages(threadWithTurns);
+          messages = hasCompleteHistory
+            ? mergeAppServerMessagesWithLocalStatus(appMessages, cachedMessages)
+            : mergeThreadMessagePages(appMessages, cachedMessages);
           messagesByThreadId.set(threadId, messages);
           loadedMessages = true;
         } else {
-          const rolloutHistory = readRolloutThreadMessages(threadId, workspacePath);
+          const rolloutHistory = readRolloutThreadMessages(
+            threadId,
+            workspacePath,
+            thread.path ?? undefined,
+          );
+          if (rolloutHistory.rolloutPath) {
+            appServerRolloutPathsByThreadId.set(threadId, rolloutHistory.rolloutPath);
+          }
           if (rolloutHistory.messages.length > 0) {
             messages = mergeThreadMessagePages(rolloutHistory.messages, cachedMessages);
             responseThread = rememberRolloutThreadMessages(
@@ -2002,13 +2117,14 @@ export function createApp(options: AppOptions = {}) {
           const threadWithTurns = await appServer.readThread(threadId, {
             includeTurns: true,
           });
+          const hasCompleteHistory = appServerThreadHasCompleteHistory(threadWithTurns);
           responseThread = rememberAppServerThread(threads, threadWithTurns, {
-            authoritativeMessageCount: true,
+            authoritativeMessageCount: hasCompleteHistory,
           });
-          messages = mergeAppServerMessagesWithLocalStatus(
-            mapAppServerMessages(threadWithTurns),
-            cachedMessages,
-          );
+          const appMessages = mapAppServerMessages(threadWithTurns);
+          messages = hasCompleteHistory
+            ? mergeAppServerMessagesWithLocalStatus(appMessages, cachedMessages)
+            : mergeThreadMessagePages(appMessages, cachedMessages);
           messagesByThreadId.set(threadId, messages);
           loadedMessages = true;
         } else if (!loadedMessages) {
@@ -3179,11 +3295,10 @@ async function createAppServerThreadRecord(input: {
   const thread = await input.appServer.startThread({
     approvalPolicy: runtime.approvalPolicy,
     cwd: input.workspacePath,
-    experimentalRawEvents: false,
     model: input.options.model ?? null,
-    persistExtendedHistory: true,
     sandbox: runtime.sandbox,
     serviceTier: input.options.serviceTier ?? null,
+    threadSource: "codex-relay",
   });
   const metadata = ThreadSummarySchema.parse({
     ...mapAppServerThread({
@@ -3452,6 +3567,13 @@ async function runPromptStreamed(input: {
     });
 
     for await (const event of streamed.events) {
+      activeThreadId = replaceLocalThreadId(
+        input.threads,
+        input.messagesByThreadId,
+        input.liveThreads,
+        activeThreadId,
+        getThreadId(thread),
+      );
       const kind = classifyStreamEvent(event);
       const text = extractStreamText(event);
 
@@ -3459,11 +3581,30 @@ async function runPromptStreamed(input: {
         throw new Error(text ?? "Codex run failed.");
       }
 
-      if (!text) {
-        continue;
-      }
-
       if (kind === "assistant") {
+        if (!text) {
+          continue;
+        }
+
+        if (isCompletedAgentMessageEvent(event)) {
+          assistantMessage = updateMessage(
+            input.messagesByThreadId,
+            activeThreadId,
+            assistantMessage.id,
+            { content: text },
+          );
+          threadSummary = updateThread(input.threads, input.messagesByThreadId, activeThreadId, {
+            state: "running",
+            lastResult: assistantMessage.content,
+          });
+          sendSse(input.controller, input.encoder, input.secureSession, {
+            type: "thread.message.created",
+            thread: threadSummary,
+            message: assistantMessage,
+          });
+          continue;
+        }
+
         const assistantPatch = appendMessageDelta(
           input.messagesByThreadId,
           activeThreadId,
@@ -3484,14 +3625,27 @@ async function runPromptStreamed(input: {
           });
         }
       } else {
-        const structured = structuredStreamMessage(kind, event, text);
-        const statusMessage = appendMessage(input.messagesByThreadId, activeThreadId, {
+        if (!text && !isRenderableStructuredStreamEvent(event)) {
+          continue;
+        }
+
+        const structured = structuredStreamMessage(kind, event, text ?? "Codex activity");
+        const itemId = firstString(eventItem(event), ["id"]);
+        const existingMessage = itemId
+          ? input.messagesByThreadId.get(activeThreadId)?.find((message) => message.id === itemId)
+          : undefined;
+        const message = {
           role: kind,
           kind: structured.kind,
           content: structured.content,
           details: structured.details,
-          state: "completed",
-        });
+          state: streamItemState(event),
+        } as const;
+        const statusMessage = existingMessage
+          ? updateMessage(input.messagesByThreadId, activeThreadId, existingMessage.id, message)
+          : itemId
+            ? appendMessageWithId(input.messagesByThreadId, activeThreadId, itemId, message)
+            : appendMessage(input.messagesByThreadId, activeThreadId, message);
         threadSummary = updateThread(input.threads, input.messagesByThreadId, activeThreadId, {
           state: "running",
         });
@@ -3559,6 +3713,7 @@ async function startAppServerTurn(
   const runtime = resolveAppServerRuntime(input.runOptions, input.workspacePath);
   const params: AppServerTurnStartParams = {
     approvalPolicy: runtime.approvalPolicy,
+    clientUserMessageId: input.id,
     collaborationMode: appServerCollaborationMode(input.runOptions),
     cwd: input.workspacePath,
     effort: input.runOptions.reasoningEffort ?? null,
@@ -3615,9 +3770,8 @@ async function resumeAppServerThread(
   await appServer.resumeThread({
     approvalPolicy: runtime.approvalPolicy,
     cwd: input.workspacePath,
-    excludeTurns: false,
+    excludeTurns: true,
     model: input.runOptions.model ?? null,
-    persistExtendedHistory: true,
     sandbox: runtime.sandbox,
     serviceTier: input.runOptions.serviceTier ?? null,
     threadId,
@@ -3700,10 +3854,12 @@ async function streamRunningAppServerThread(input: {
   let observedInputRequest = false;
   let observedTurnActivity = false;
   let producedTurnOutput = false;
+  const asyncAgentMessageIds = new Set<string>();
   let threadSummary = input.threads.get(input.threadId);
   let cleanupNotificationHandler = (): void => undefined;
   let cleanupRequestHandler = (): void => undefined;
   let handlersCleaned = false;
+  let streamFinished = false;
 
   const cleanupHandlers = () => {
     if (handlersCleaned) {
@@ -3735,6 +3891,7 @@ async function streamRunningAppServerThread(input: {
     if (approval.kind === "structuredUserInput") {
       const pending = {
         appServer: input.appServer,
+        isBlocking: approval.isBlocking,
         kind: approval.kind,
         method: request.method,
         questions: approval.questions,
@@ -3787,6 +3944,7 @@ async function streamRunningAppServerThread(input: {
         return;
       }
       settled = true;
+      streamFinished = true;
       cleanupHandlers();
       if (error === undefined) {
         resolve();
@@ -3803,6 +3961,26 @@ async function streamRunningAppServerThread(input: {
 
       try {
         switch (notification.method) {
+          case "serverRequest/resolved": {
+            const requestId = appServerRequestIdFromParams(params);
+            if (requestId === undefined) {
+              return;
+            }
+            const approvalId = appServerApprovalId(input.threadId, requestId);
+            const pending = input.pendingApprovals.get(approvalId);
+            if (!pending || pending.threadId !== input.threadId) {
+              return;
+            }
+            input.pendingApprovals.delete(approvalId);
+            if (pending.kind === "structuredUserInput") {
+              sendSse(input.controller, input.encoder, input.secureSession, {
+                type: "thread.input_request.resolved",
+                requestId: approvalId,
+                threadId: input.threadId,
+              });
+            }
+            return;
+          }
           case "thread/status/changed": {
             const state = mapAppServerThreadState(params?.status);
             if (state !== "running" && observedTurnActivity) {
@@ -3858,15 +4036,21 @@ async function streamRunningAppServerThread(input: {
             if (!message) {
               return;
             }
-            if (message.role !== "user") {
+            const isAsyncAgentMessage = isAsyncAppServerAgentMessage(item as AppServerThreadItem);
+            if (isAsyncAgentMessage) {
+              asyncAgentMessageIds.add(message.id);
+            }
+            if (message.role !== "user" && !isAsyncAgentMessage) {
               producedTurnOutput = true;
             }
-            if (message.role === "assistant") {
+            if (message.role === "assistant" && !isAsyncAgentMessage) {
               assistantMessageId = message.id;
             }
             threadSummary = updateThread(input.threads, input.messagesByThreadId, input.threadId, {
               state: "running",
-              lastResult: message.role === "assistant" ? message.content : undefined,
+              ...(message.role === "assistant" && !isAsyncAgentMessage
+                ? { lastResult: message.content }
+                : {}),
             });
             sendSse(input.controller, input.encoder, input.secureSession, {
               type:
@@ -3893,8 +4077,11 @@ async function streamRunningAppServerThread(input: {
                 turnId: firstString(params, ["turnId"]) ?? activeTurnId,
               });
             }
-            assistantMessageId = itemId;
-            producedTurnOutput = true;
+            const isAsyncAgentMessage = asyncAgentMessageIds.has(itemId);
+            if (!isAsyncAgentMessage) {
+              assistantMessageId = itemId;
+              producedTurnOutput = true;
+            }
             const patch = appendMessageDelta(
               input.messagesByThreadId,
               input.threadId,
@@ -3904,7 +4091,7 @@ async function streamRunningAppServerThread(input: {
             const message = patch.message;
             updateThread(input.threads, input.messagesByThreadId, input.threadId, {
               state: "running",
-              lastResult: message.content,
+              ...(isAsyncAgentMessage ? {} : { lastResult: message.content }),
             });
             if (patch.delta) {
               sendSse(input.controller, input.encoder, input.secureSession, {
@@ -3944,6 +4131,50 @@ async function streamRunningAppServerThread(input: {
           case "turn/failed": {
             observedTurnActivity = true;
             const state = terminalTurnState(notification.method, params);
+            const terminalTurn = appServerTurnFromParams(params);
+            if (terminalTurn) {
+              activeTurnId = terminalTurn.id;
+              for (const item of terminalTurn.items) {
+                const message = upsertAppServerItemMessage(
+                  input.messagesByThreadId,
+                  input.threadId,
+                  terminalTurn.id,
+                  item,
+                );
+                if (!message) {
+                  continue;
+                }
+                const isAsyncAgentMessage = isAsyncAppServerAgentMessage(item);
+                if (isAsyncAgentMessage) {
+                  asyncAgentMessageIds.add(message.id);
+                }
+                if (message.role !== "user" && !isAsyncAgentMessage) {
+                  producedTurnOutput = true;
+                }
+                if (message.role === "assistant" && !isAsyncAgentMessage) {
+                  assistantMessageId = message.id;
+                }
+                threadSummary = updateThread(
+                  input.threads,
+                  input.messagesByThreadId,
+                  input.threadId,
+                  {
+                    state: "running",
+                    ...(message.role === "assistant" && !isAsyncAgentMessage
+                      ? { lastResult: message.content }
+                      : {}),
+                  },
+                );
+                sendSse(input.controller, input.encoder, input.secureSession, {
+                  type:
+                    message.role === "assistant"
+                      ? "thread.message.completed"
+                      : "thread.message.created",
+                  thread: threadSummary,
+                  message,
+                });
+              }
+            }
             relayDebugLog("app_server.turn.terminal", {
               method: notification.method,
               state,
@@ -3963,7 +4194,12 @@ async function streamRunningAppServerThread(input: {
               finish();
               return;
             }
-            if (assistantMessageId) {
+            const assistantMessage = assistantMessageId
+              ? input.messagesByThreadId
+                  .get(input.threadId)
+                  ?.find((message) => message.id === assistantMessageId)
+              : undefined;
+            if (assistantMessageId && assistantMessage?.state !== "completed") {
               const completedMessage = updateMessage(
                 input.messagesByThreadId,
                 input.threadId,
@@ -4031,10 +4267,16 @@ async function streamRunningAppServerThread(input: {
 
   try {
     const appServerThread = await Promise.race([
-      input.appServer.readThread(input.threadId, { includeTurns: false }),
+      typeof input.appServer.resumeThread === "function"
+        ? input.appServer.resumeThread({ excludeTurns: true, threadId: input.threadId })
+        : input.appServer.readThread(input.threadId, { includeTurns: false }),
       aborted.then(() => undefined),
     ]);
     if (!appServerThread || input.signal.aborted) {
+      return;
+    }
+    if (streamFinished) {
+      await completed;
       return;
     }
     threadSummary = rememberAppServerThread(input.threads, appServerThread);
@@ -4105,6 +4347,7 @@ async function runAppServerPromptStreamed(input: {
   let handedOffToQueuedTurn = false;
   let observedInputRequest = false;
   let producedTurnOutput = false;
+  const asyncAgentMessageIds = new Set<string>();
 
   let userMessage = appendMessage(input.messagesByThreadId, activeThreadId, {
     role: "user",
@@ -4150,6 +4393,7 @@ async function runAppServerPromptStreamed(input: {
     if (approval.kind === "structuredUserInput") {
       const pending = {
         appServer: input.appServer,
+        isBlocking: approval.isBlocking,
         kind: approval.kind,
         method: request.method,
         questions: approval.questions,
@@ -4252,7 +4496,12 @@ async function runAppServerPromptStreamed(input: {
       return;
     }
 
-    if (assistantMessageId) {
+    const assistantMessage = assistantMessageId
+      ? input.messagesByThreadId
+          .get(activeThreadId)
+          ?.find((message) => message.id === assistantMessageId)
+      : undefined;
+    if (assistantMessageId && assistantMessage?.state !== "completed") {
       const completedMessage = updateMessage(
         input.messagesByThreadId,
         activeThreadId,
@@ -4329,10 +4578,7 @@ async function runAppServerPromptStreamed(input: {
     resolveCompleted();
   }
 
-  async function processReturnedTurn(turn: AppServerTurn) {
-    if (finalizedTurnIds.has(turn.id)) {
-      return;
-    }
+  function processTurnItems(turn: AppServerTurn) {
     activeTurnId = turn.id;
     input.activeAppServerTurnIdsByThreadId.set(activeThreadId, turn.id);
     const turnIsRunning = isAppServerTurnRunning(turn);
@@ -4376,15 +4622,21 @@ async function runAppServerPromptStreamed(input: {
       if (!message) {
         continue;
       }
-      if (message.role !== "user") {
+      const isAsyncAgentMessage = isAsyncAppServerAgentMessage(item);
+      if (isAsyncAgentMessage) {
+        asyncAgentMessageIds.add(message.id);
+      }
+      if (message.role !== "user" && !isAsyncAgentMessage) {
         producedTurnOutput = true;
       }
-      if (message.role === "assistant" && turnIsRunning) {
+      if (message.role === "assistant" && !isAsyncAgentMessage) {
         assistantMessageId = message.id;
       }
       threadSummary = updateThread(input.threads, input.messagesByThreadId, activeThreadId, {
         state: "running",
-        lastResult: message.role === "assistant" ? message.content : undefined,
+        ...(message.role === "assistant" && !isAsyncAgentMessage
+          ? { lastResult: message.content }
+          : {}),
       });
       sendSse(input.controller, input.encoder, input.secureSession, {
         type: message.role === "assistant" ? "thread.message.completed" : "thread.message.created",
@@ -4392,6 +4644,15 @@ async function runAppServerPromptStreamed(input: {
         message,
       });
     }
+
+    return turnIsRunning;
+  }
+
+  async function processReturnedTurn(turn: AppServerTurn) {
+    if (finalizedTurnIds.has(turn.id)) {
+      return;
+    }
+    const turnIsRunning = processTurnItems(turn);
 
     if (turnIsRunning) {
       return;
@@ -4429,6 +4690,26 @@ async function runAppServerPromptStreamed(input: {
 
       try {
         switch (notification.method) {
+          case "serverRequest/resolved": {
+            const requestId = appServerRequestIdFromParams(params);
+            if (requestId === undefined) {
+              return;
+            }
+            const approvalId = appServerApprovalId(activeThreadId, requestId);
+            const pending = input.pendingApprovals.get(approvalId);
+            if (!pending || pending.threadId !== activeThreadId) {
+              return;
+            }
+            input.pendingApprovals.delete(approvalId);
+            if (pending.kind === "structuredUserInput") {
+              sendSse(input.controller, input.encoder, input.secureSession, {
+                type: "thread.input_request.resolved",
+                requestId: approvalId,
+                threadId: activeThreadId,
+              });
+            }
+            return;
+          }
           case "thread/status/changed": {
             const status = params?.status;
             const state = mapAppServerThreadState(status);
@@ -4509,15 +4790,21 @@ async function runAppServerPromptStreamed(input: {
             if (!message) {
               return;
             }
-            if (message.role !== "user") {
+            const isAsyncAgentMessage = isAsyncAppServerAgentMessage(item as AppServerThreadItem);
+            if (isAsyncAgentMessage) {
+              asyncAgentMessageIds.add(message.id);
+            }
+            if (message.role !== "user" && !isAsyncAgentMessage) {
               producedTurnOutput = true;
             }
-            if (message.role === "assistant") {
+            if (message.role === "assistant" && !isAsyncAgentMessage) {
               assistantMessageId = message.id;
             }
             threadSummary = updateThread(input.threads, input.messagesByThreadId, activeThreadId, {
               state: "running",
-              lastResult: message.role === "assistant" ? message.content : undefined,
+              ...(message.role === "assistant" && !isAsyncAgentMessage
+                ? { lastResult: message.content }
+                : {}),
             });
             sendSse(input.controller, input.encoder, input.secureSession, {
               type:
@@ -4543,7 +4830,10 @@ async function runAppServerPromptStreamed(input: {
                 turnId: firstString(params, ["turnId"]) ?? activeTurnId,
               });
             }
-            assistantMessageId = itemId;
+            const isAsyncAgentMessage = asyncAgentMessageIds.has(itemId);
+            if (!isAsyncAgentMessage) {
+              assistantMessageId = itemId;
+            }
             const patch = appendMessageDelta(
               input.messagesByThreadId,
               activeThreadId,
@@ -4551,10 +4841,12 @@ async function runAppServerPromptStreamed(input: {
               delta,
             );
             const message = patch.message;
-            producedTurnOutput = true;
+            if (!isAsyncAgentMessage) {
+              producedTurnOutput = true;
+            }
             updateThread(input.threads, input.messagesByThreadId, activeThreadId, {
               state: "running",
-              lastResult: message.content,
+              ...(isAsyncAgentMessage ? {} : { lastResult: message.content }),
             });
             if (patch.delta) {
               sendSse(input.controller, input.encoder, input.secureSession, {
@@ -4592,18 +4884,28 @@ async function runAppServerPromptStreamed(input: {
           case "turn/completed":
           case "turn/failed": {
             const state = terminalTurnState(notification.method, params);
+            const terminalTurn = appServerTurnFromParams(params);
             const terminalTurnId =
               firstString(params, ["turnId"]) ?? turnIdFromParams(params) ?? activeTurnId;
             void input
               .runThreadOperation(activeThreadId, async () => {
-                await input.runAppServerMutation(activeThreadId, () =>
-                  finishTerminalTurn({
+                await input.runAppServerMutation(activeThreadId, async () => {
+                  if (
+                    (terminalTurnId && finalizedTurnIds.has(terminalTurnId)) ||
+                    (terminalTurnId && activeTurnId && terminalTurnId !== activeTurnId)
+                  ) {
+                    return;
+                  }
+                  if (terminalTurn && terminalTurn.id === terminalTurnId) {
+                    processTurnItems(terminalTurn);
+                  }
+                  await finishTerminalTurn({
                     lastError: state === "failed" ? turnErrorMessage(params) : undefined,
                     method: notification.method,
                     state,
                     turnId: terminalTurnId,
-                  }),
-                );
+                  });
+                });
               })
               .catch((error: unknown) => {
                 cleanupNotificationHandler();
@@ -4627,42 +4929,40 @@ async function runAppServerPromptStreamed(input: {
       `wait idle gate first=${isFirstLocalMessage ? "1" : "0"} active=${activeTurnId ?? "none"}`,
       activeThreadId,
     );
-    if (activeTurnId) {
-      debugStream("wait idle begin", activeThreadId);
-      await waitForAppServerThreadIdle({
-        appServer: input.appServer,
-        onWaiting() {
-          if (waitingForActiveTurnMessageId) {
-            return;
-          }
-          const message = appendMessage(input.messagesByThreadId, activeThreadId, {
-            role: "status",
-            content: "Waiting for the current Codex turn to finish.",
-            state: "streaming",
-          });
-          waitingForActiveTurnMessageId = message.id;
-          threadSummary = updateThread(input.threads, input.messagesByThreadId, activeThreadId, {
-            state: "running",
-          });
-          sendSse(input.controller, input.encoder, input.secureSession, {
-            type: "thread.message.created",
-            thread: threadSummary,
-            message,
-          });
-        },
-        onWaitingHeartbeat() {
-          threadSummary = updateThread(input.threads, input.messagesByThreadId, activeThreadId, {
-            state: "running",
-          });
-          sendSse(input.controller, input.encoder, input.secureSession, {
-            type: "thread.state.changed",
-            thread: threadSummary,
-          });
-        },
-        threadId: activeThreadId,
-      });
-      debugStream("wait idle complete", activeThreadId);
-    }
+    debugStream("wait idle begin", activeThreadId);
+    await waitForAppServerThreadIdle({
+      appServer: input.appServer,
+      onWaiting() {
+        if (waitingForActiveTurnMessageId) {
+          return;
+        }
+        const message = appendMessage(input.messagesByThreadId, activeThreadId, {
+          role: "status",
+          content: "Waiting for the current Codex turn to finish.",
+          state: "streaming",
+        });
+        waitingForActiveTurnMessageId = message.id;
+        threadSummary = updateThread(input.threads, input.messagesByThreadId, activeThreadId, {
+          state: "running",
+        });
+        sendSse(input.controller, input.encoder, input.secureSession, {
+          type: "thread.message.created",
+          thread: threadSummary,
+          message,
+        });
+      },
+      onWaitingHeartbeat() {
+        threadSummary = updateThread(input.threads, input.messagesByThreadId, activeThreadId, {
+          state: "running",
+        });
+        sendSse(input.controller, input.encoder, input.secureSession, {
+          type: "thread.state.changed",
+          thread: threadSummary,
+        });
+      },
+      threadId: activeThreadId,
+    });
+    debugStream("wait idle complete", activeThreadId);
     if (waitingForActiveTurnMessageId) {
       const message = updateMessage(
         input.messagesByThreadId,
@@ -4684,7 +4984,7 @@ async function runAppServerPromptStreamed(input: {
     try {
       turn = await startAndProcessAppServerTurn(activeThreadId, {
         attachments: input.attachments,
-        id: randomUUID(),
+        id: userMessage.id,
         prompt,
         runOptions: input.runOptions,
         skills: input.skills,
@@ -4725,7 +5025,7 @@ async function runAppServerPromptStreamed(input: {
       });
       turn = await startAndProcessAppServerTurn(activeThreadId, {
         attachments: input.attachments,
-        id: randomUUID(),
+        id: userMessage.id,
         prompt,
         runOptions: input.runOptions,
         skills: input.skills,
@@ -4891,11 +5191,10 @@ async function recoverMissingAppServerThread(input: {
   const thread = await input.appServer.startThread({
     approvalPolicy: runtime.approvalPolicy,
     cwd: input.workspacePath,
-    experimentalRawEvents: false,
     model: input.runOptions.model ?? null,
-    persistExtendedHistory: true,
     sandbox: runtime.sandbox,
     serviceTier: input.runOptions.serviceTier ?? null,
+    threadSource: "codex-relay",
   });
   const recoveredThread = mapAppServerThread({
     ...thread,
@@ -5144,9 +5443,12 @@ function upsertAppServerItemMessage(
     return undefined;
   }
 
-  const existing = messagesByThreadId.get(threadId)?.some((candidate) => candidate.id === item.id);
+  const existing = messagesByThreadId.get(threadId)?.find((candidate) => candidate.id === item.id);
   if (existing) {
-    return updateMessage(messagesByThreadId, threadId, item.id, message);
+    return updateMessage(messagesByThreadId, threadId, item.id, {
+      ...message,
+      createdAt: existing.createdAt,
+    });
   }
 
   return appendMessageWithId(messagesByThreadId, threadId, item.id, {
@@ -5191,6 +5493,10 @@ function isDuplicateInitialUserMessage(
 ) {
   if (item.type !== "userMessage" || !("content" in item) || !Array.isArray(item.content)) {
     return false;
+  }
+
+  if (item.clientId) {
+    return item.clientId === localMessageId;
   }
 
   const localMessage = messagesByThreadId
@@ -6253,6 +6559,7 @@ function mapAppServerThread(
 ): ThreadMetadata {
   const createdAt = fromUnixSeconds(thread.createdAt);
   const updatedAt = fromUnixSeconds(thread.updatedAt);
+  const lastActivityAt = fromUnixSeconds(thread.recencyAt ?? thread.updatedAt);
   const messageCount = Math.max(
     thread.turns ? countThreadMessages(thread) : 0,
     fallbackMessageCount ?? 0,
@@ -6269,7 +6576,7 @@ function mapAppServerThread(
     source: thread.source,
     messageCount,
     lastMessagePreview: thread.preview ? preview(thread.preview) : undefined,
-    lastActivityAt: updatedAt,
+    lastActivityAt,
   });
 }
 
@@ -6347,6 +6654,16 @@ function mapAppServerMessages(thread: AppServerThread): ChatMessage[] {
     }
   }
   return messages;
+}
+
+function appServerThreadHasCompleteHistory(thread: AppServerThread) {
+  return (thread.turns ?? []).every(
+    (turn) => turn.itemsView === undefined || turn.itemsView === "full",
+  );
+}
+
+function isAsyncAppServerAgentMessage(item: AppServerThreadItem) {
+  return item.type === "agentMessage" && "delivery" in item && item.delivery === "async";
 }
 
 function mergeAppServerMessagesWithLocalStatus(
@@ -6581,9 +6898,19 @@ function readSessionIndexThreadTitle(threadId: string) {
   return undefined;
 }
 
-function readRolloutThreadMessages(threadId: string, workspacePath = defaultWorkspacePath) {
-  const rolloutPath = findRolloutFileForThread(threadId);
+function readRolloutThreadMessages(
+  threadId: string,
+  workspacePath = defaultWorkspacePath,
+  selectedRolloutPath?: string,
+) {
+  const rolloutPath =
+    selectedRolloutPath && selectedRolloutPath.endsWith(".jsonl") && existsSync(selectedRolloutPath)
+      ? selectedRolloutPath
+      : findRolloutFileForThread(threadId);
   if (!rolloutPath) {
+    return { messageCountLowerBound: 0, messages: [], rolloutPath };
+  }
+  if (isPaginatedRolloutFile(rolloutPath)) {
     return { messageCountLowerBound: 0, messages: [], rolloutPath };
   }
 
@@ -6662,6 +6989,35 @@ function readRolloutThreadMessages(threadId: string, workspacePath = defaultWork
     messages: collected,
     rolloutPath,
   };
+}
+
+function isPaginatedRolloutFile(rolloutPath: string) {
+  let descriptor: number | undefined;
+  try {
+    descriptor = openSync(rolloutPath, "r");
+    const buffer = Buffer.allocUnsafe(64 * 1024);
+    const bytesRead = readSync(descriptor, buffer, 0, buffer.length, 0);
+    const prefix = buffer.toString("utf8", 0, bytesRead);
+    for (const line of prefix.split("\n")) {
+      if (!line.trim()) {
+        continue;
+      }
+      const record = JSON.parse(line) as {
+        payload?: Record<string, unknown>;
+        type?: unknown;
+      };
+      if (record.type === "session_meta") {
+        return record.payload?.history_mode === "paginated";
+      }
+    }
+  } catch {
+    return false;
+  } finally {
+    if (descriptor !== undefined) {
+      closeSync(descriptor);
+    }
+  }
+  return false;
 }
 
 function findRolloutFileForThread(threadId: string) {
@@ -7238,12 +7594,17 @@ function mapAppServerItem(threadId: string, turn: AppServerTurn, item: AppServer
       const agentItem = item as Extract<AppServerThreadItem, { type: "agentMessage" }>;
       const planContent = proposedPlanContent(agentItem.text);
       const messageParts = appServerAgentMessageParts(agentItem);
+      const details = planContent
+        ? { raw: agentItem.text }
+        : agentItem.delivery || messageParts.details
+          ? { ...messageParts.details, delivery: agentItem.delivery ?? undefined }
+          : undefined;
       return ChatMessageSchema.parse({
         ...base,
         role: "assistant",
         kind: planContent ? "plan" : undefined,
         content: planContent ?? messageParts.content,
-        details: planContent ? { raw: agentItem.text } : messageParts.details,
+        details,
       });
     }
     case "reasoning": {
@@ -7691,6 +8052,25 @@ function structuredStreamMessage(
           type,
         },
       };
+    case "todo_list": {
+      const items = Array.isArray(item?.items) ? item.items : [];
+      const content = items
+        .flatMap((entry) => {
+          if (!entry || typeof entry !== "object") {
+            return [];
+          }
+          const todo = entry as Record<string, unknown>;
+          return typeof todo.text === "string"
+            ? [`[${todo.completed === true ? "x" : " "}] ${todo.text}`]
+            : [];
+        })
+        .join("\n");
+      return {
+        kind: "plan",
+        content: content || fallbackContent,
+        details: { items, type },
+      };
+    }
     default:
       return {
         kind: kindFromProtocolType(type) ?? (role === "tool" ? "toolActivity" : "unknown"),
@@ -7698,6 +8078,33 @@ function structuredStreamMessage(
         details: { type },
       };
   }
+}
+
+function isCompletedAgentMessageEvent(event: unknown) {
+  if (!event || typeof event !== "object") {
+    return false;
+  }
+
+  return (
+    (event as Record<string, unknown>).type === "item.completed" &&
+    eventItem(event)?.type === "agent_message"
+  );
+}
+
+function isRenderableStructuredStreamEvent(event: unknown) {
+  const type = eventItem(event)?.type;
+  return (
+    type === "file_change" ||
+    type === "mcp_tool_call" ||
+    type === "todo_list" ||
+    type === "web_search"
+  );
+}
+
+function streamItemState(event: unknown): "streaming" | "completed" {
+  return (event as Record<string, unknown> | null)?.type === "item.completed"
+    ? "completed"
+    : "streaming";
 }
 
 function isApprovalServerRequest(method: string) {
@@ -7812,7 +8219,7 @@ function approvalMessageFromRequest(request: AppServerRequest) {
     return undefined;
   }
 
-  const approvalId = `approval-${request.id}`;
+  const approvalId = appServerApprovalId(threadId, request.id);
   switch (request.method) {
     case "item/commandExecution/requestApproval": {
       const command = firstString(params, ["command"]) ?? "Command execution";
@@ -7905,6 +8312,7 @@ function approvalMessageFromRequest(request: AppServerRequest) {
           questions,
         },
         kind: "structuredUserInput" as const,
+        isBlocking: typeof params?.isBlocking === "boolean" ? params.isBlocking : true,
         questions,
         threadId,
         turnId,
@@ -7991,6 +8399,7 @@ function pendingInputOptions(value: unknown) {
 function pendingInputRequestFromApproval(
   approval: {
     approvalId: string;
+    isBlocking?: boolean;
     questions?: PendingInputRequestQuestion[];
     turnId?: string;
   },
@@ -7998,6 +8407,7 @@ function pendingInputRequestFromApproval(
 ): PendingInputRequest {
   return {
     id: approval.approvalId,
+    isBlocking: approval.isBlocking ?? true,
     questions: approval.questions ?? [],
     threadId,
     turnId: approval.turnId,
@@ -8015,6 +8425,7 @@ function pendingInputRequestsForThread(
     return [
       {
         id: approvalId,
+        isBlocking: pending.isBlocking ?? true,
         questions: pending.questions ?? [],
         threadId,
         turnId: pending.turnId,
@@ -8176,6 +8587,35 @@ function turnIdFromParams(params: Record<string, unknown> | undefined) {
   return turn && typeof turn === "object"
     ? firstString(turn as Record<string, unknown>, ["id"])
     : undefined;
+}
+
+function appServerRequestIdFromParams(params: Record<string, unknown> | undefined) {
+  const requestId = params?.requestId;
+  return typeof requestId === "number" || typeof requestId === "string" ? requestId : undefined;
+}
+
+function appServerApprovalId(threadId: string, requestId: number | string) {
+  const digest = createHash("sha256")
+    .update(threadId)
+    .update("\0")
+    .update(String(requestId))
+    .digest("hex")
+    .slice(0, 24);
+  return `approval-${digest}`;
+}
+
+function appServerTurnFromParams(
+  params: Record<string, unknown> | undefined,
+): AppServerTurn | undefined {
+  const turn = params?.turn;
+  if (!turn || typeof turn !== "object") {
+    return undefined;
+  }
+  const record = turn as Record<string, unknown>;
+  if (typeof record.id !== "string" || !Array.isArray(record.items)) {
+    return undefined;
+  }
+  return turn as AppServerTurn;
 }
 
 function turnStatus(params: Record<string, unknown> | undefined) {

--- a/packages/codex-relay/src/codex-binary.ts
+++ b/packages/codex-relay/src/codex-binary.ts
@@ -1,9 +1,11 @@
+import { createRequire } from "node:module";
 import { platform as currentPlatform } from "node:os";
-import { extname } from "node:path";
+import { dirname, extname, join } from "node:path";
 
 const stdioAppServerArgs = ["app-server", "--listen", "stdio://"] as const;
 const sharedWindowsServerUrl = "ws://127.0.0.1:8788";
 const windowsShellExtensions = new Set([".bat", ".cmd"]);
+const require = createRequire(import.meta.url);
 
 type CodexSpawnPlatform = NodeJS.Platform;
 
@@ -53,13 +55,13 @@ export function resolveCodexAppServerSpawn(
 ): CodexAppServerSpawn {
   const platform = input.platform ?? currentPlatform();
   const env = input.env ?? process.env;
-  const command = resolveCodexBinary(env);
+  const executable = resolveCodexExecutable(env);
   const isWindows = platform === "win32";
 
   return {
-    command,
-    args: [...stdioAppServerArgs],
-    shell: isWindows && shouldUseWindowsShell(command),
+    command: executable.command,
+    args: [...executable.args, ...stdioAppServerArgs],
+    shell: isWindows && executable.explicit && shouldUseWindowsShell(executable.command),
     windowsHide: isWindows,
   };
 }
@@ -68,13 +70,18 @@ export function resolveCodexSharedAppServerSpawn(
   input: CodexAppServerSpawnInput = {},
 ): CodexAppServerSpawn {
   const platform = input.platform ?? currentPlatform();
-  const command = resolveCodexBinary(input.env ?? process.env);
+  const executable = resolveCodexExecutable(input.env ?? process.env);
   const isWindows = platform === "win32";
 
   return {
-    command,
-    args: ["app-server", "--listen", resolveCodexSharedAppServerRemoteAddress(platform)],
-    shell: isWindows && shouldUseWindowsShell(command),
+    command: executable.command,
+    args: [
+      ...executable.args,
+      "app-server",
+      "--listen",
+      resolveCodexSharedAppServerRemoteAddress(platform),
+    ],
+    shell: isWindows && executable.explicit && shouldUseWindowsShell(executable.command),
     windowsHide: isWindows,
   };
 }
@@ -85,8 +92,17 @@ export function resolveCodexSharedAppServerRemoteAddress(
   return platform === "win32" ? sharedWindowsServerUrl : "unix://";
 }
 
-function resolveCodexBinary(env: NodeJS.ProcessEnv) {
-  return env.CODEX_BIN?.trim() || "codex";
+function resolveCodexExecutable(env: NodeJS.ProcessEnv) {
+  const configuredBinary = env.CODEX_BIN?.trim();
+  if (configuredBinary) {
+    return { args: [] as string[], command: configuredBinary, explicit: true };
+  }
+  const packagePath = require.resolve("@openai/codex/package.json");
+  return {
+    args: [join(dirname(packagePath), "bin", "codex.js")],
+    command: process.execPath,
+    explicit: false,
+  };
 }
 
 function shouldUseWindowsShell(command: string) {

--- a/packages/codex-relay/src/codex.ts
+++ b/packages/codex-relay/src/codex.ts
@@ -1,5 +1,4 @@
-import { Codex } from "@openai/codex-sdk";
-import type { KnownReasoningEffort } from "./api-schema.js";
+import { Codex, type ThreadOptions as SdkThreadOptions } from "@openai/codex-sdk";
 
 export type CodexRunResult = unknown;
 
@@ -14,14 +13,7 @@ export type CodexThread = {
   runStreamed?(prompt: string, options?: unknown): Promise<CodexStreamedResult>;
 };
 
-export type CodexThreadOptions = {
-  approvalPolicy?: "never" | "on-request" | "on-failure" | "untrusted";
-  model?: string;
-  modelReasoningEffort?: KnownReasoningEffort;
-  sandboxMode?: "read-only" | "workspace-write" | "danger-full-access";
-  workingDirectory?: string;
-  skipGitRepoCheck?: boolean;
-};
+export type CodexThreadOptions = SdkThreadOptions;
 
 export type CodexClient = {
   startThread(options?: CodexThreadOptions): CodexThread;
@@ -68,11 +60,17 @@ export function extractStreamText(event: unknown) {
     record.item && typeof record.item === "object"
       ? (record.item as Record<string, unknown>)
       : undefined;
+  const error =
+    record.error && typeof record.error === "object"
+      ? (record.error as Record<string, unknown>)
+      : undefined;
   const candidate =
     record.delta ??
     record.text ??
     record.message ??
+    error?.message ??
     item?.text ??
+    item?.message ??
     item?.aggregated_output ??
     item?.command;
 

--- a/packages/codex-relay/test/app-server.test.ts
+++ b/packages/codex-relay/test/app-server.test.ts
@@ -13,8 +13,9 @@ import { CodexAppServerClient } from "../src/app-server.js";
 import { relayDebugLog } from "../src/debug-log.js";
 
 type JsonRpcRequest = {
-  id: number;
+  id?: number;
   method: string;
+  params?: Record<string, unknown>;
 };
 
 type SharedSocketServer = {
@@ -45,6 +46,11 @@ describe("CodexAppServerClient shared socket mode", () => {
     try {
       await client.initialize();
       expect(server.connections).toHaveLength(1);
+      await vi.waitFor(() => {
+        expect(server.requests.filter((request) => request.method === "initialized")).toHaveLength(
+          1,
+        );
+      });
       expect(startSharedServer).not.toHaveBeenCalled();
       expect(relayDebugLog).toHaveBeenCalledWith("app_server.shared_socket.connected", {
         ownership: "attached",
@@ -54,6 +60,7 @@ describe("CodexAppServerClient shared socket mode", () => {
         ownership: "attached",
         socketPath,
       });
+      await client.resumeThread({ threadId: "thread-active" });
 
       server.connections[0]?.terminate();
 
@@ -65,6 +72,21 @@ describe("CodexAppServerClient shared socket mode", () => {
       );
       await expect(client.listModels()).resolves.toEqual([]);
       expect(server.requests.filter((request) => request.method === "initialize")).toHaveLength(2);
+      expect(server.requests.filter((request) => request.method === "thread/resume")).toHaveLength(
+        2,
+      );
+      expect(
+        server.requests.filter((request) => request.method === "thread/resume").at(-1)?.params,
+      ).toEqual({
+        excludeTurns: true,
+        initialTurnsPage: { itemsView: "summary", limit: 1, sortDirection: "desc" },
+        threadId: "thread-active",
+      });
+      await vi.waitFor(() => {
+        expect(server.requests.filter((request) => request.method === "initialized")).toHaveLength(
+          2,
+        );
+      });
       expect(startSharedServer).not.toHaveBeenCalled();
       expect(client.appServerMode).toBe("socket");
       expect(relayDebugLog).toHaveBeenCalledWith(
@@ -75,6 +97,137 @@ describe("CodexAppServerClient shared socket mode", () => {
         ownership: "attached",
         socketPath,
       });
+    } finally {
+      client.close();
+      await server.close();
+      await rm(codexHome, { force: true, recursive: true });
+    }
+  });
+
+  it("replays a turn that completed while the shared socket was disconnected", async () => {
+    const codexHome = await mkdtemp(join(socketTempRoot, "codex-relay-app-server-gap-"));
+    const socketPath = join(codexHome, "app-server-control", "app-server-control.sock");
+    const now = Date.now() / 1_000;
+    let resumedTurn: {
+      id: string;
+      items: Array<Record<string, unknown>>;
+      itemsView: string;
+      status: string;
+      error: null;
+      startedAt: number;
+      completedAt: number | null;
+      durationMs: number | null;
+    } = {
+      id: "turn-gap",
+      items: [],
+      itemsView: "notLoaded",
+      status: "inProgress",
+      error: null,
+      startedAt: now,
+      completedAt: null,
+      durationMs: null,
+    };
+    const server = await startSharedSocketServer(socketPath, (request) => {
+      if (request.method !== "thread/resume") {
+        return request.method === "model/list" ? { data: [] } : {};
+      }
+      return {
+        initialTurnsPage: { data: [resumedTurn] },
+        thread: {
+          id: "thread-gap",
+          status: { type: resumedTurn.status === "inProgress" ? "active" : "idle" },
+          turns: [],
+        },
+      };
+    });
+    vi.stubEnv("CODEX_HOME", codexHome);
+    vi.stubEnv("CODEX_RELAY_APP_SERVER_MODE", "socket");
+    const client = new CodexAppServerClient({
+      startSharedServer: async () => {
+        throw new Error("Expected the client to attach to the existing shared app-server.");
+      },
+    });
+    const notifications: Array<{ method: string; params: unknown }> = [];
+    client.onNotification((notification) => notifications.push(notification));
+
+    try {
+      await client.initialize();
+      await client.resumeThread({ excludeTurns: true, threadId: "thread-gap" });
+      resumedTurn = {
+        ...resumedTurn,
+        items: [
+          {
+            id: "assistant-gap",
+            text: "Recovered after reconnect",
+            type: "agentMessage",
+          },
+        ],
+        itemsView: "summary",
+        status: "completed",
+        completedAt: now + 1,
+        durationMs: 1_000,
+      };
+
+      server.connections[0]?.terminate();
+
+      await vi.waitFor(
+        () => {
+          expect(notifications).toContainEqual({
+            method: "turn/completed",
+            params: {
+              threadId: "thread-gap",
+              turn: resumedTurn,
+            },
+          });
+        },
+        { timeout: 5_000 },
+      );
+      expect(
+        server.requests.filter((request) => request.method === "thread/resume").at(-1)?.params,
+      ).toEqual({
+        excludeTurns: true,
+        initialTurnsPage: { itemsView: "summary", limit: 1, sortDirection: "desc" },
+        threadId: "thread-gap",
+      });
+    } finally {
+      client.close();
+      await server.close();
+      await rm(codexHome, { force: true, recursive: true });
+    }
+  });
+
+  it("lists every root thread page in server recency order", async () => {
+    const codexHome = await mkdtemp(join(socketTempRoot, "codex-relay-app-server-pages-"));
+    const socketPath = join(codexHome, "app-server-control", "app-server-control.sock");
+    const server = await startSharedSocketServer(socketPath, (request) => {
+      if (request.method !== "thread/list") {
+        return {};
+      }
+      return request.params?.cursor === "page-2"
+        ? { data: [{ id: "thread-older" }], nextCursor: null }
+        : { data: [{ id: "thread-newer" }], nextCursor: "page-2" };
+    });
+    vi.stubEnv("CODEX_HOME", codexHome);
+    vi.stubEnv("CODEX_RELAY_APP_SERVER_MODE", "socket");
+    const client = new CodexAppServerClient({
+      startSharedServer: async () => {
+        throw new Error("Expected the client to attach to the existing shared app-server.");
+      },
+    });
+
+    try {
+      const threads = await client.listThreads(1);
+      const requests = server.requests.filter((request) => request.method === "thread/list");
+
+      expect(threads.map((thread) => thread.id)).toEqual(["thread-newer", "thread-older"]);
+      expect(requests).toHaveLength(2);
+      expect(requests[0]?.params).toMatchObject({
+        limit: 1,
+        sortKey: "recency_at",
+        sortDirection: "desc",
+        sourceKinds: ["cli", "vscode", "exec", "appServer"],
+      });
+      expect(requests[1]?.params).toMatchObject({ cursor: "page-2" });
     } finally {
       client.close();
       await server.close();
@@ -146,7 +299,15 @@ process.stdin.resume();
   );
 });
 
-async function startSharedSocketServer(socketPath: string): Promise<SharedSocketServer> {
+async function startSharedSocketServer(
+  socketPath: string,
+  responseForRequest: (request: JsonRpcRequest) => unknown = (request) =>
+    request.method === "model/list"
+      ? { data: [] }
+      : request.method === "thread/resume"
+        ? { thread: { id: request.params?.threadId } }
+        : {},
+): Promise<SharedSocketServer> {
   await mkdir(dirname(socketPath), { recursive: true });
   const connections: WebSocket[] = [];
   const requests: JsonRpcRequest[] = [];
@@ -157,10 +318,13 @@ async function startSharedSocketServer(socketPath: string): Promise<SharedSocket
     socket.on("message", (data) => {
       const request = JSON.parse(String(data)) as JsonRpcRequest;
       requests.push(request);
+      if (typeof request.id !== "number") {
+        return;
+      }
       socket.send(
         JSON.stringify({
           id: request.id,
-          result: request.method === "model/list" ? { data: [] } : {},
+          result: responseForRequest(request),
         }),
       );
     });

--- a/packages/codex-relay/test/app.test.ts
+++ b/packages/codex-relay/test/app.test.ts
@@ -6,6 +6,7 @@ import { sha256 } from "@noble/hashes/sha2.js";
 import { fromByteArray, toByteArray } from "base64-js";
 import { execFile } from "node:child_process";
 import { mkdtemp, mkdir, readFile, symlink, writeFile } from "node:fs/promises";
+import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import { basename, dirname, join } from "node:path";
 import { promisify } from "node:util";
@@ -22,6 +23,8 @@ import type { PushNotificationSender, RelayPushNotification } from "../src/push-
 import { createServerIdentity } from "../src/secure-transport.js";
 
 const execFileAsync = promisify(execFile);
+const requirePackage = createRequire(import.meta.url);
+const relayPackage = requirePackage("../package.json") as { version: string };
 
 function createMockCodex(handlers?: {
   onResumeThread?: (threadId: string, options: Parameters<CodexClient["resumeThread"]>[1]) => void;
@@ -212,7 +215,7 @@ describe("Codex Relay server routes", () => {
       ok: true,
       service: "codex-relay-server",
       packageName: "codex-relay",
-      packageVersion: expect.any(String),
+      packageVersion: relayPackage.version,
     });
   });
 

--- a/packages/codex-relay/test/app.test.ts
+++ b/packages/codex-relay/test/app.test.ts
@@ -1860,22 +1860,29 @@ describe("Codex Relay server routes", () => {
   it("rewinds an app-server thread from a selected user turn", async () => {
     const workspacePath = await mkdtemp(join(tmpdir(), "codex-relay-workspace-"));
     const now = Date.now() / 1000;
-    const beforeRewind = appServerHistoryThread({
-      id: "app-thread-rewind",
-      name: "Rewind history",
-      turns: [
-        appServerTurn("turn-1", "First prompt", now),
-        appServerTurn("turn-2", "Second prompt", now + 10),
-      ],
-      workspacePath,
-    });
-    const afterRewind = appServerHistoryThread({
-      id: "app-thread-rewind",
-      name: "Rewind history",
-      turns: [appServerTurn("turn-1", "First prompt", now)],
-      workspacePath,
-    });
+    const beforeRewind = {
+      ...appServerHistoryThread({
+        id: "app-thread-rewind",
+        name: "Rewind history",
+        turns: [
+          appServerTurn("turn-1", "First prompt", now),
+          appServerTurn("turn-2", "Second prompt", now + 10),
+        ],
+        workspacePath,
+      }),
+      historyMode: "paginated" as const,
+    };
+    const afterRewind = {
+      ...appServerHistoryThread({
+        id: "app-thread-rewind",
+        name: "Rewind history",
+        turns: [appServerTurn("turn-1", "First prompt", now)],
+        workspacePath,
+      }),
+      historyMode: "paginated" as const,
+    };
     const rollbackThread = vi.fn<() => Promise<unknown>>(async () => afterRewind);
+    const revertThread = vi.fn<() => Promise<unknown>>(async () => afterRewind);
     const appServer = {
       onNotification() {
         return () => undefined;
@@ -1884,6 +1891,7 @@ describe("Codex Relay server routes", () => {
         return () => undefined;
       },
       readThread: vi.fn<() => Promise<unknown>>(async () => beforeRewind),
+      revertThread,
       rollbackThread,
     };
     const app = createApp({
@@ -1900,11 +1908,67 @@ describe("Codex Relay server routes", () => {
     const body = await response.json();
 
     expect(response.status).toBe(200);
-    expect(rollbackThread).toHaveBeenCalledWith({ threadId: "app-thread-rewind", numTurns: 1 });
+    expect(revertThread).toHaveBeenCalledWith({
+      beforeTurnId: "turn-2",
+      threadId: "app-thread-rewind",
+    });
+    expect(rollbackThread).not.toHaveBeenCalled();
     expect(body.messages.map((message: { id: string }) => message.id)).toEqual([
       "turn-1-user",
       "turn-1-assistant",
     ]);
+  });
+
+  it("uses legacy rollback instead of paginated revert for legacy history", async () => {
+    const workspacePath = await mkdtemp(join(tmpdir(), "codex-relay-workspace-"));
+    const now = Date.now() / 1000;
+    const beforeRewind = {
+      ...appServerHistoryThread({
+        id: "app-thread-legacy-rewind",
+        name: "Legacy rewind",
+        turns: [
+          appServerTurn("turn-1", "First prompt", now),
+          appServerTurn("turn-2", "Second prompt", now + 10),
+        ],
+        workspacePath,
+      }),
+      historyMode: "legacy" as const,
+    };
+    const afterRewind = {
+      ...beforeRewind,
+      turns: [appServerTurn("turn-1", "First prompt", now)],
+    };
+    const rollbackThread = vi.fn<() => Promise<unknown>>(async () => afterRewind);
+    const revertThread = vi.fn<() => Promise<unknown>>(async () => afterRewind);
+    const appServer = {
+      onNotification() {
+        return () => undefined;
+      },
+      onRequest() {
+        return () => undefined;
+      },
+      readThread: vi.fn<() => Promise<unknown>>(async () => beforeRewind),
+      revertThread,
+      rollbackThread,
+    };
+    const app = createApp({
+      appServer: appServer as never,
+      codex: createMockCodex(),
+      workspacePath,
+    });
+
+    const response = await app.request("/v1/threads/app-thread-legacy-rewind/rollback", {
+      method: "POST",
+      body: JSON.stringify({ turnId: "turn-2" }),
+      headers: { "content-type": "application/json" },
+    });
+
+    expect(response.status).toBe(200);
+    expect(rollbackThread).toHaveBeenCalledWith({
+      numTurns: 1,
+      threadId: "app-thread-legacy-rewind",
+    });
+    expect(revertThread).not.toHaveBeenCalled();
   });
 
   it("serializes rewind with an app-server turn start", async () => {
@@ -2236,6 +2300,9 @@ describe("Codex Relay server routes", () => {
         };
       },
       readThread: vi.fn<() => Promise<unknown>>(async () => {
+        return appThread;
+      }),
+      resumeThread: vi.fn<() => Promise<unknown>>(async () => {
         queueMicrotask(() => {
           for (const handler of notificationHandlers) {
             handler({
@@ -2259,15 +2326,50 @@ describe("Codex Relay server routes", () => {
       headers: { "content-type": "application/json" },
     });
     const body = await response.text();
+    const stateEvents = body
+      .split("\n")
+      .filter((line) => line.startsWith("data: "))
+      .map((line) => JSON.parse(line.slice("data: ".length)) as Record<string, unknown>)
+      .filter((event) => event.type === "thread.state.changed");
 
     expect(response.status).toBe(200);
-    expect(appServer.readThread).toHaveBeenCalled();
-    expect(body).toContain('"state":"running"');
+    expect(appServer.resumeThread).toHaveBeenCalledWith({
+      excludeTurns: true,
+      threadId: "app-thread-empty-stream",
+    });
     expect(body).toContain('"state":"idle"');
-    expect(notificationHandlers).toHaveLength(0);
+    expect((stateEvents.at(-1)?.thread as { state?: string } | undefined)?.state).toBe("idle");
+    expect(notificationHandlers).toHaveLength(1);
     expect(requestHandlers).toHaveLength(0);
     expect(cleanupNotificationHandler).toHaveBeenCalledTimes(1);
     expect(cleanupRequestHandler).toHaveBeenCalledTimes(1);
+
+    appThread.status = { type: "idle" };
+    for (const handler of notificationHandlers) {
+      handler({
+        method: "item/completed",
+        params: {
+          item: {
+            id: "late-background-item",
+            type: "commandExecution",
+            command: "pnpm test",
+            aggregatedOutput: "passed",
+            status: "completed",
+          },
+          threadId: appThread.id,
+          turnId: "completed-turn",
+        },
+      });
+    }
+    const detailResponse = await app.request(`/v1/threads/${appThread.id}`);
+    const detail = await detailResponse.json();
+    expect(detail.messages).toContainEqual(
+      expect.objectContaining({
+        id: "late-background-item",
+        kind: "commandExecution",
+        role: "tool",
+      }),
+    );
   });
 
   it("does not accumulate preview probes or app-server handlers across cancelled attachments", async () => {
@@ -2342,7 +2444,7 @@ describe("Codex Relay server routes", () => {
         await vi.advanceTimersByTimeAsync(0);
 
         expect(fetchPreview).toHaveBeenCalledTimes(attachment);
-        expect(notificationHandlers).toHaveLength(1);
+        expect(notificationHandlers).toHaveLength(2);
         expect(requestHandlers).toHaveLength(1);
 
         await reader!.cancel("test cancellation");
@@ -2351,7 +2453,7 @@ describe("Codex Relay server routes", () => {
         expect(probeSignals[attachment - 1]?.aborted).toBe(true);
         await vi.advanceTimersByTimeAsync(4500);
         expect(fetchPreview).toHaveBeenCalledTimes(attachment);
-        expect(notificationHandlers).toHaveLength(0);
+        expect(notificationHandlers).toHaveLength(1);
         expect(requestHandlers).toHaveLength(0);
         expect(cleanupNotificationHandler).toHaveBeenCalledTimes(attachment);
         expect(cleanupRequestHandler).toHaveBeenCalledTimes(attachment);
@@ -4222,20 +4324,12 @@ describe("Codex Relay server routes", () => {
       preview: "Interruptible thread",
       createdAt: now,
       updatedAt: now,
-      status: { type: "running" },
+      status: { type: "idle" },
       cwd: workspacePath,
       source: "app-server",
       modelProvider: "openai",
       name: "Interruptible thread",
-      turns: [
-        {
-          id: "turn-interrupt",
-          items: [],
-          status: { type: "running" },
-          startedAt: now,
-          completedAt: null,
-        },
-      ],
+      turns: [],
     };
     const interruptTurn = vi.fn<() => Promise<void>>(async () => undefined);
     const startTurn = vi.fn<() => Promise<unknown>>(async () => ({
@@ -4387,57 +4481,60 @@ describe("Codex Relay server routes", () => {
       },
       readThread: vi.fn<() => Promise<unknown>>(async () => appThread),
       startThread: vi.fn<() => Promise<unknown>>(async () => appThread),
-      startTurn: vi.fn<() => Promise<unknown>>(async () => {
-        queueMicrotask(() => {
-          for (const handler of notificationHandlers) {
-            handler({
-              method: "turn/started",
-              params: {
-                threadId: appThread.id,
-                turn: { id: "turn-canonical-user" },
-              },
-            });
-            handler({
-              method: "item/completed",
-              params: {
-                item: {
-                  id: "user-canonical",
-                  content: [{ type: "text", text: "Remember the turn", text_elements: [] }],
-                  type: "userMessage",
+      startTurn: vi.fn<(params: { clientUserMessageId?: string }) => Promise<unknown>>(
+        async (params) => {
+          queueMicrotask(() => {
+            for (const handler of notificationHandlers) {
+              handler({
+                method: "turn/started",
+                params: {
+                  threadId: appThread.id,
+                  turn: { id: "turn-canonical-user" },
                 },
-                threadId: appThread.id,
-                turnId: "turn-canonical-user",
-              },
-            });
-            handler({
-              method: "item/completed",
-              params: {
-                item: {
-                  id: "assistant-canonical",
-                  text: "Remembered",
-                  type: "agentMessage",
+              });
+              handler({
+                method: "item/completed",
+                params: {
+                  item: {
+                    id: "user-canonical",
+                    clientId: params.clientUserMessageId,
+                    content: [{ type: "text", text: "Remember the turn", text_elements: [] }],
+                    type: "userMessage",
+                  },
+                  threadId: appThread.id,
+                  turnId: "turn-canonical-user",
                 },
-                threadId: appThread.id,
-                turnId: "turn-canonical-user",
-              },
-            });
-            handler({
-              method: "turn/completed",
-              params: {
-                threadId: appThread.id,
-                turnId: "turn-canonical-user",
-              },
-            });
-          }
-        });
-        return {
-          id: "turn-canonical-user",
-          items: [],
-          status: "inProgress",
-          startedAt: now,
-          completedAt: null,
-        };
-      }),
+              });
+              handler({
+                method: "item/completed",
+                params: {
+                  item: {
+                    id: "assistant-canonical",
+                    text: "Remembered",
+                    type: "agentMessage",
+                  },
+                  threadId: appThread.id,
+                  turnId: "turn-canonical-user",
+                },
+              });
+              handler({
+                method: "turn/completed",
+                params: {
+                  threadId: appThread.id,
+                  turnId: "turn-canonical-user",
+                },
+              });
+            }
+          });
+          return {
+            id: "turn-canonical-user",
+            items: [],
+            status: "inProgress",
+            startedAt: now,
+            completedAt: null,
+          };
+        },
+      ),
     };
     const app = createApp({
       appServer: appServer as never,
@@ -4477,6 +4574,9 @@ describe("Codex Relay server routes", () => {
     );
 
     expect(response.status).toBe(200);
+    expect(appServer.startTurn).toHaveBeenCalledWith(
+      expect.objectContaining({ clientUserMessageId: userEvents[0]?.message?.id }),
+    );
     expect(userEvents).toHaveLength(2);
     expect(userEvents[1]?.message).toMatchObject({
       id: "user-canonical",
@@ -4715,6 +4815,123 @@ describe("Codex Relay server routes", () => {
     expect(body).toContain('"delta":" world"');
     expect(body).not.toContain('"delta":"Hello world"');
     expect(body).toContain('"content":"Hello world"');
+  });
+
+  it("recovers missing assistant deltas from the completed app-server turn summary", async () => {
+    const workspacePath = await mkdtemp(join(tmpdir(), "codex-relay-workspace-"));
+    const notificationHandlers = new Set<(notification: unknown) => void>();
+    const now = Date.now() / 1000;
+    const appServer = {
+      onNotification(handler: (notification: unknown) => void) {
+        notificationHandlers.add(handler);
+        return () => notificationHandlers.delete(handler);
+      },
+      onRequest() {
+        return () => undefined;
+      },
+      startThread: vi.fn<() => Promise<unknown>>(async () => ({
+        id: "app-thread-summary-recovery",
+        createdAt: now,
+        cwd: workspacePath,
+        modelProvider: "gpt-5.5",
+        name: "Summary recovery",
+        preview: "Summary recovery",
+        source: "app",
+        status: "idle",
+        turns: [],
+        updatedAt: now,
+      })),
+      startTurn: vi.fn<() => Promise<unknown>>(async () => {
+        queueMicrotask(() => {
+          for (const handler of notificationHandlers) {
+            handler({
+              method: "item/agentMessage/delta",
+              params: {
+                delta: "Hello",
+                itemId: "assistant-summary-recovery",
+                threadId: "app-thread-summary-recovery",
+                turnId: "turn-summary-recovery",
+              },
+            });
+            handler({
+              method: "turn/completed",
+              params: {
+                threadId: "app-thread-summary-recovery",
+                turn: {
+                  id: "turn-summary-recovery",
+                  items: [
+                    {
+                      id: "assistant-summary-recovery",
+                      text: "Hello world",
+                      type: "agentMessage",
+                    },
+                  ],
+                  itemsView: "summary",
+                  status: "completed",
+                  error: null,
+                  startedAt: now,
+                  completedAt: now,
+                  durationMs: 1,
+                },
+              },
+            });
+          }
+        });
+        return {
+          id: "turn-summary-recovery",
+          items: [],
+          itemsView: "notLoaded",
+          status: "inProgress",
+          startedAt: now,
+          completedAt: null,
+        };
+      }),
+    };
+    const app = createApp({
+      appServer: appServer as never,
+      codex: createMockCodex(),
+      workspacePath,
+    });
+
+    await app.request("/v1/threads", {
+      method: "POST",
+      body: JSON.stringify({ title: "Summary recovery" }),
+      headers: { "content-type": "application/json" },
+    });
+    const response = await app.request("/v1/threads/app-thread-summary-recovery/runs/stream", {
+      method: "POST",
+      body: JSON.stringify({ prompt: "Recover the final response" }),
+      headers: { "content-type": "application/json" },
+    });
+    const body = await response.text();
+    const events = body
+      .split("\n")
+      .filter((line) => line.startsWith("data: "))
+      .map((line) => JSON.parse(line.slice("data: ".length)) as Record<string, unknown>);
+    const completedMessageIndex = events.findIndex(
+      (event) =>
+        event.type === "thread.message.completed" &&
+        (event.message as { id?: string } | undefined)?.id === "assistant-summary-recovery" &&
+        (event.message as { content?: string } | undefined)?.content === "Hello world",
+    );
+    const completedStateIndex = events.findIndex(
+      (event) =>
+        event.type === "thread.state.changed" &&
+        (event.thread as { state?: string } | undefined)?.state === "completed",
+    );
+
+    expect(response.status).toBe(200);
+    expect(body).toContain('"delta":"Hello"');
+    expect(body).not.toContain('"delta":" world"');
+    expect(body).not.toContain("thread.error");
+    expect(completedMessageIndex).toBeGreaterThan(-1);
+    expect(completedStateIndex).toBeGreaterThan(completedMessageIndex);
+    expect(events[completedMessageIndex]?.message).toMatchObject({
+      content: "Hello world",
+      id: "assistant-summary-recovery",
+      state: "completed",
+      turnId: "turn-summary-recovery",
+    });
   });
 
   it("fails app-server streamed turns that complete without any response", async () => {
@@ -5086,6 +5303,126 @@ describe("Codex Relay server routes", () => {
     expect(body).toContain('"state":"completed"');
   });
 
+  it("ignores a late completion from the previous turn after queued handoff", async () => {
+    const workspacePath = await mkdtemp(join(tmpdir(), "codex-relay-workspace-"));
+    const notificationHandlers = new Set<(notification: unknown) => void>();
+    const now = Date.now() / 1000;
+    let releaseFirstTurn!: () => void;
+    const firstTurnReleased = new Promise<void>((resolve) => {
+      releaseFirstTurn = resolve;
+    });
+    let turnCount = 0;
+    const threadId = "app-thread-late-previous-turn";
+    const startTurn = vi.fn<() => Promise<unknown>>(async () => {
+      turnCount += 1;
+      if (turnCount === 1) {
+        await firstTurnReleased;
+        return {
+          id: "turn-previous",
+          items: [{ id: "assistant-previous", text: "first direct reply", type: "agentMessage" }],
+          status: "completed",
+          startedAt: now,
+          completedAt: now,
+        };
+      }
+      queueMicrotask(() => {
+        for (const handler of notificationHandlers) {
+          handler({
+            method: "turn/completed",
+            params: {
+              threadId,
+              turn: {
+                id: "turn-previous",
+                items: [
+                  {
+                    id: "assistant-stale-previous",
+                    text: "stale previous summary",
+                    type: "agentMessage",
+                  },
+                ],
+                status: "completed",
+                error: null,
+                startedAt: now,
+                completedAt: now,
+              },
+            },
+          });
+          handler({
+            method: "item/completed",
+            params: {
+              item: { id: "assistant-current", text: "current queued reply", type: "agentMessage" },
+              threadId,
+              turnId: "turn-current",
+            },
+          });
+          handler({
+            method: "turn/completed",
+            params: { status: "completed", threadId, turnId: "turn-current" },
+          });
+        }
+      });
+      return {
+        id: "turn-current",
+        items: [],
+        status: "running",
+        startedAt: now,
+        completedAt: null,
+      };
+    });
+    const appServer = {
+      onNotification(handler: (notification: unknown) => void) {
+        notificationHandlers.add(handler);
+        return () => notificationHandlers.delete(handler);
+      },
+      onRequest() {
+        return () => undefined;
+      },
+      startThread: vi.fn<() => Promise<unknown>>(async () => ({
+        id: threadId,
+        createdAt: now,
+        cwd: workspacePath,
+        modelProvider: "gpt-5.5",
+        name: "Late previous turn",
+        preview: "Late previous turn",
+        source: "app",
+        status: "idle",
+        turns: [],
+        updatedAt: now,
+      })),
+      startTurn,
+    };
+    const app = createApp({
+      appServer: appServer as never,
+      codex: createMockCodex(),
+      workspacePath,
+    });
+
+    await app.request("/v1/threads", {
+      method: "POST",
+      body: JSON.stringify({ title: "Late previous turn" }),
+      headers: { "content-type": "application/json" },
+    });
+    const streamResponse = await app.request(`/v1/threads/${threadId}/runs/stream`, {
+      method: "POST",
+      body: JSON.stringify({ prompt: "Initial run" }),
+      headers: { "content-type": "application/json" },
+    });
+    await waitUntil(() => expect(startTurn).toHaveBeenCalledTimes(1));
+    const queuedResponse = await app.request(`/v1/threads/${threadId}/input`, {
+      method: "POST",
+      body: JSON.stringify({ prompt: "Queued run" }),
+      headers: { "content-type": "application/json" },
+    });
+    releaseFirstTurn();
+    const body = await streamResponse.text();
+
+    expect(queuedResponse.status).toBe(202);
+    expect(startTurn).toHaveBeenCalledTimes(2);
+    expect(body).toContain("first direct reply");
+    expect(body).toContain("current queued reply");
+    expect(body).not.toContain("stale previous summary");
+  });
+
   it("does not stream terminal thread status before late assistant items", async () => {
     const workspacePath = await mkdtemp(join(tmpdir(), "codex-relay-workspace-"));
     const notificationHandlers = new Set<(notification: unknown) => void>();
@@ -5178,6 +5515,143 @@ describe("Codex Relay server routes", () => {
     expect(response.status).toBe(200);
     expect(assistantIndex).toBeGreaterThan(-1);
     expect(completedStateIndex).toBeGreaterThan(assistantIndex);
+  });
+
+  it("keeps async agent delivery out of the turn's final response", async () => {
+    const workspacePath = await mkdtemp(join(tmpdir(), "codex-relay-workspace-"));
+    const notificationHandlers = new Set<(notification: unknown) => void>();
+    const now = Date.now() / 1000;
+    const threadId = "app-thread-async-delivery";
+    const appServer = {
+      onNotification(handler: (notification: unknown) => void) {
+        notificationHandlers.add(handler);
+        return () => notificationHandlers.delete(handler);
+      },
+      onRequest() {
+        return () => undefined;
+      },
+      startThread: vi.fn<() => Promise<unknown>>(async () => ({
+        id: threadId,
+        createdAt: now,
+        cwd: workspacePath,
+        modelProvider: "gpt-5.5",
+        name: "Async delivery",
+        preview: "Async delivery",
+        source: "app",
+        status: "idle",
+        turns: [],
+        updatedAt: now,
+      })),
+      startTurn: vi.fn<() => Promise<unknown>>(async () => {
+        queueMicrotask(() => {
+          for (const handler of notificationHandlers) {
+            handler({
+              method: "turn/started",
+              params: { threadId, turnId: "turn-async-delivery" },
+            });
+            handler({
+              method: "item/started",
+              params: {
+                item: { id: "assistant-final", text: "", type: "agentMessage" },
+                threadId,
+                turnId: "turn-async-delivery",
+              },
+            });
+            handler({
+              method: "item/agentMessage/delta",
+              params: {
+                delta: "final answer",
+                itemId: "assistant-final",
+                threadId,
+                turnId: "turn-async-delivery",
+              },
+            });
+            handler({
+              method: "item/completed",
+              params: {
+                item: { id: "assistant-final", text: "final answer", type: "agentMessage" },
+                threadId,
+                turnId: "turn-async-delivery",
+              },
+            });
+            handler({
+              method: "item/started",
+              params: {
+                item: {
+                  delivery: "async",
+                  id: "assistant-background",
+                  text: "",
+                  type: "agentMessage",
+                },
+                threadId,
+                turnId: "turn-async-delivery",
+              },
+            });
+            handler({
+              method: "item/agentMessage/delta",
+              params: {
+                delta: "background note",
+                itemId: "assistant-background",
+                threadId,
+                turnId: "turn-async-delivery",
+              },
+            });
+            handler({
+              method: "item/completed",
+              params: {
+                item: {
+                  delivery: "async",
+                  id: "assistant-background",
+                  text: "background note",
+                  type: "agentMessage",
+                },
+                threadId,
+                turnId: "turn-async-delivery",
+              },
+            });
+            handler({
+              method: "turn/completed",
+              params: { status: "completed", threadId, turnId: "turn-async-delivery" },
+            });
+          }
+        });
+        return {
+          id: "turn-async-delivery",
+          items: [],
+          status: "running",
+          startedAt: now,
+          completedAt: null,
+        };
+      }),
+    };
+    const app = createApp({
+      appServer: appServer as never,
+      codex: createMockCodex(),
+      workspacePath,
+    });
+
+    await app.request("/v1/threads", {
+      method: "POST",
+      body: JSON.stringify({ title: "Async delivery" }),
+      headers: { "content-type": "application/json" },
+    });
+    const streamResponse = await app.request(`/v1/threads/${threadId}/runs/stream`, {
+      method: "POST",
+      body: JSON.stringify({ prompt: "Finish normally" }),
+      headers: { "content-type": "application/json" },
+    });
+    await streamResponse.text();
+    const detailResponse = await app.request(`/v1/threads/${threadId}`);
+    const detailBody = await detailResponse.json();
+
+    expect(detailResponse.status).toBe(200);
+    expect(detailBody.thread.lastResult).toBe("final answer");
+    expect(detailBody.messages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "assistant-final", content: "final answer" }),
+        expect.objectContaining({ id: "assistant-background", content: "background note" }),
+      ]),
+    );
   });
 
   it("waits for late assistant notifications when startTurn returns completed without items", async () => {
@@ -5462,8 +5936,6 @@ describe("Codex Relay server routes", () => {
     expect(response.status).toBe(200);
     expect(appServer.resumeThread).toHaveBeenCalledWith(
       expect.objectContaining({
-        excludeTurns: false,
-        persistExtendedHistory: true,
         threadId: "app-thread-not-loaded",
       }),
     );
@@ -5547,8 +6019,11 @@ describe("Codex Relay server routes", () => {
     const body = await response.text();
 
     expect(response.status).toBe(200);
-    expect(appServer.readThread).toHaveBeenCalled();
+    expect(appServer.readThread).toHaveBeenCalledTimes(3);
     expect(appServer.startTurn).toHaveBeenCalledTimes(1);
+    expect(appServer.readThread.mock.invocationCallOrder[1]).toBeLessThan(
+      appServer.startTurn.mock.invocationCallOrder[0]!,
+    );
     expect(body).toContain("thread.message.delta");
     expect(body).toContain("pong");
   });
@@ -5712,13 +6187,20 @@ describe("Codex Relay server routes", () => {
     });
     await waitUntil(() => expect(approvalRequested).toBe(true));
 
-    const firstApproval = app.request("/v1/approvals/approval-42", {
+    const pendingDetailResponse = await app.request("/v1/threads/app-thread-approval");
+    const pendingDetailBody = await pendingDetailResponse.json();
+    const approvalId = pendingDetailBody.messages.find(
+      (message: { details?: { approvalId?: string } }) => message.details?.approvalId,
+    )?.details?.approvalId;
+    expect(approvalId).toMatch(/^approval-[a-f0-9]{24}$/);
+
+    const firstApproval = app.request(`/v1/approvals/${approvalId}`, {
       method: "POST",
       body: JSON.stringify({ decision: "approve" }),
       headers: { "content-type": "application/json" },
     });
     await waitUntil(() => expect(respondToRequest).toHaveBeenCalledTimes(1));
-    const duplicateApproval = app.request("/v1/approvals/approval-42", {
+    const duplicateApproval = app.request(`/v1/approvals/${approvalId}`, {
       method: "POST",
       body: JSON.stringify({ decision: "approve" }),
       headers: { "content-type": "application/json" },
@@ -5793,9 +6275,10 @@ describe("Codex Relay server routes", () => {
           inputRequested = true;
           for (const handler of requestHandlers) {
             handler({
-              id: 7,
+              id: "request-7",
               method: "item/tool/requestUserInput",
               params: {
+                isBlocking: false,
                 questions: [
                   {
                     header: "Scope",
@@ -5838,9 +6321,11 @@ describe("Codex Relay server routes", () => {
 
     const detailBeforeResponse = await app.request("/v1/threads/app-thread-input");
     const detailBeforeBody = await detailBeforeResponse.json();
+    const pendingInputRequest = detailBeforeBody.pendingInputRequests[0];
     expect(detailBeforeBody.pendingInputRequests).toContainEqual(
       expect.objectContaining({
-        id: "approval-7",
+        id: expect.stringMatching(/^approval-[a-f0-9]{24}$/),
+        isBlocking: false,
         questions: [
           expect.objectContaining({
             id: "scope",
@@ -5853,7 +6338,7 @@ describe("Codex Relay server routes", () => {
       expect.objectContaining({ kind: "structuredUserInput" }),
     );
 
-    const approvalResponse = await app.request("/v1/approvals/approval-7", {
+    const approvalResponse = await app.request(`/v1/approvals/${pendingInputRequest.id}`, {
       method: "POST",
       body: JSON.stringify({ decision: "approve", answers: ["Restart Vite"] }),
       headers: { "content-type": "application/json" },
@@ -5864,7 +6349,7 @@ describe("Codex Relay server routes", () => {
 
     expect(approvalResponse.status).toBe(200);
     expect(streamBody).toContain("thread.input_request.created");
-    expect(respondToRequest).toHaveBeenCalledWith(7, {
+    expect(respondToRequest).toHaveBeenCalledWith("request-7", {
       answers: { scope: { answers: ["Restart Vite"] } },
     });
     expect(streamBody).toContain('"state":"completed"');
@@ -6524,6 +7009,73 @@ describe("Codex Relay server routes", () => {
     expect(body).not.toHaveProperty("olderMessagesCursor");
   });
 
+  it("preserves cached full items when refreshed app-server history is summary-only", async () => {
+    const workspacePath = await mkdtemp(join(tmpdir(), "codex-relay-workspace-"));
+    const now = Date.now() / 1000;
+    const fullTurn = {
+      ...appServerTurn("turn-summary-history", "Full user message", now),
+      itemsView: "full",
+    };
+    const summaryTurn = {
+      ...fullTurn,
+      items: [fullTurn.items[1]],
+      itemsView: "summary",
+    };
+    const baseThread = appServerHistoryThread({
+      id: "app-thread-summary-history",
+      name: "Summary history",
+      turns: [fullTurn],
+      workspacePath,
+    });
+    let fullReadCount = 0;
+    const readThread = vi.fn<
+      (_threadId: string, options?: { includeTurns?: boolean }) => Promise<unknown>
+    >(async (_threadId, options) => {
+      if (options?.includeTurns === false) {
+        return { ...baseThread, turns: undefined };
+      }
+      fullReadCount += 1;
+      return {
+        ...baseThread,
+        turns: fullReadCount === 1 ? [fullTurn] : [summaryTurn],
+      };
+    });
+    const appServer = {
+      listThreads: vi.fn<() => Promise<unknown[]>>(async () => [baseThread]),
+      onNotification() {
+        return () => undefined;
+      },
+      onRequest() {
+        return () => undefined;
+      },
+      readThread,
+    };
+    const app = createApp({
+      appServer: appServer as never,
+      codex: createMockCodex(),
+      workspacePath,
+    });
+
+    const initialResponse = await app.request("/v1/threads/app-thread-summary-history");
+    const refreshedResponse = await app.request(
+      "/v1/threads/app-thread-summary-history?refresh=true",
+    );
+    const initialBody = await initialResponse.json();
+    const refreshedBody = await refreshedResponse.json();
+
+    expect(initialResponse.status).toBe(200);
+    expect(refreshedResponse.status).toBe(200);
+    expect(initialBody.messages.map((message: { id: string }) => message.id)).toEqual([
+      "turn-summary-history-user",
+      "turn-summary-history-assistant",
+    ]);
+    expect(refreshedBody.messages.map((message: { id: string }) => message.id)).toEqual([
+      "turn-summary-history-user",
+      "turn-summary-history-assistant",
+    ]);
+    expect(refreshedBody.thread.messageCount).toBe(2);
+  });
+
   it("loads app-server history from the rollout file when full thread reads hang", async () => {
     const workspacePath = await mkdtemp(join(tmpdir(), "codex-relay-workspace-"));
     const codexHome = await mkdtemp(join(tmpdir(), "codex-relay-home-"));
@@ -6601,6 +7153,269 @@ describe("Codex Relay server routes", () => {
       expect(body).not.toHaveProperty("hasMoreMessages");
       expect(body).not.toHaveProperty("olderMessagesCursor");
       expect(body.thread.messageCount).toBe(2);
+    } finally {
+      process.env.CODEX_HOME = previousCodexHome;
+    }
+  });
+
+  it("prefers the app-server thread path when multiple rollout files share a thread id", async () => {
+    const workspacePath = await mkdtemp(join(tmpdir(), "codex-relay-workspace-"));
+    const codexHome = await mkdtemp(join(tmpdir(), "codex-relay-home-"));
+    const sessionsRoot = join(codexHome, "sessions");
+    const sessionsDir = join(sessionsRoot, "2026", "08", "26");
+    await mkdir(sessionsDir, { recursive: true });
+    const threadId = "app-thread-selected-rollout";
+    const decoyPath = join(sessionsRoot, `rollout-decoy-${threadId}.jsonl`);
+    const selectedPath = join(
+      sessionsDir,
+      `rollout-2026-08-26T00-00-00-${threadId}_current-rollout.jsonl`,
+    );
+    const rolloutLines = (prompt: string, answer: string) =>
+      [
+        JSON.stringify({
+          payload: { turn_id: "turn-selected-rollout", type: "task_started" },
+          timestamp: "2026-08-26T00:00:00.000Z",
+          type: "event_msg",
+        }),
+        JSON.stringify({
+          payload: { message: prompt, type: "user_message" },
+          timestamp: "2026-08-26T00:00:01.000Z",
+          type: "event_msg",
+        }),
+        JSON.stringify({
+          payload: { message: answer, type: "agent_message" },
+          timestamp: "2026-08-26T00:00:02.000Z",
+          type: "event_msg",
+        }),
+      ].join("\n");
+    await writeFile(decoyPath, rolloutLines("old prompt", "old answer"));
+    await writeFile(
+      selectedPath,
+      `${rolloutLines("current prompt", "current answer")}\n${JSON.stringify({
+        payload: { message: "removed by revert", type: "agent_message" },
+        timestamp: "2026-08-26T00:00:03.000Z",
+        type: "event_msg",
+      })}`,
+    );
+    const previousCodexHome = process.env.CODEX_HOME;
+    process.env.CODEX_HOME = codexHome;
+    const notificationHandlers = new Set<(notification: unknown) => void>();
+    const now = Date.now() / 1000;
+    const appThread = {
+      id: threadId,
+      createdAt: now,
+      cwd: workspacePath,
+      modelProvider: "gpt-5.5",
+      name: "Selected rollout",
+      path: selectedPath,
+      preview: "Selected rollout",
+      source: "app",
+      status: { type: "notLoaded" },
+      updatedAt: now,
+    };
+    const readThread = vi.fn<
+      (_threadId: string, options?: { includeTurns?: boolean }) => Promise<unknown>
+    >(async () => appThread);
+    const appServer = {
+      listThreads: vi.fn<() => Promise<unknown[]>>(async () => [appThread]),
+      onNotification(handler: (notification: unknown) => void) {
+        notificationHandlers.add(handler);
+        return () => notificationHandlers.delete(handler);
+      },
+      onRequest() {
+        return () => undefined;
+      },
+      readThread,
+    };
+    const app = createApp({
+      appServer: appServer as never,
+      codex: createMockCodex(),
+      workspacePath,
+    });
+
+    try {
+      const response = await app.request(`/v1/threads/${threadId}`);
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(readThread).toHaveBeenCalledTimes(1);
+      expect(body.messages.map((message: { content: string }) => message.content)).toEqual([
+        "current prompt",
+        "current answer",
+        "removed by revert",
+      ]);
+
+      await writeFile(selectedPath, rolloutLines("reverted prompt", "reverted answer"));
+      for (const handler of notificationHandlers) {
+        handler({ method: "thread/reverted", params: { threadId } });
+      }
+      const revertedResponse = await app.request(`/v1/threads/${threadId}`);
+      const revertedBody = await revertedResponse.json();
+
+      expect(revertedResponse.status).toBe(200);
+      expect(revertedBody.messages.map((message: { content: string }) => message.content)).toEqual([
+        "reverted prompt",
+        "reverted answer",
+      ]);
+    } finally {
+      process.env.CODEX_HOME = previousCodexHome;
+    }
+  });
+
+  it("replaces fallback rollout history when app-server later reports a different path", async () => {
+    const workspacePath = await mkdtemp(join(tmpdir(), "codex-relay-workspace-"));
+    const codexHome = await mkdtemp(join(tmpdir(), "codex-relay-home-"));
+    const sessionsRoot = join(codexHome, "sessions");
+    const selectedDir = join(sessionsRoot, "2026", "08", "26");
+    await mkdir(selectedDir, { recursive: true });
+    const threadId = "app-thread-late-rollout-path";
+    const fallbackPath = join(sessionsRoot, `rollout-fallback-${threadId}.jsonl`);
+    const selectedPath = join(selectedDir, `rollout-selected-${threadId}.jsonl`);
+    const rolloutLines = (prompt: string, answer: string) =>
+      [
+        JSON.stringify({
+          payload: { turn_id: `turn-${prompt}`, type: "task_started" },
+          timestamp: "2026-08-26T00:00:00.000Z",
+          type: "event_msg",
+        }),
+        JSON.stringify({
+          payload: { message: prompt, type: "user_message" },
+          timestamp: "2026-08-26T00:00:01.000Z",
+          type: "event_msg",
+        }),
+        JSON.stringify({
+          payload: { message: answer, type: "agent_message" },
+          timestamp: "2026-08-26T00:00:02.000Z",
+          type: "event_msg",
+        }),
+      ].join("\n");
+    await writeFile(fallbackPath, rolloutLines("old prompt", "old answer"));
+    const previousCodexHome = process.env.CODEX_HOME;
+    process.env.CODEX_HOME = codexHome;
+    const now = Date.now() / 1000;
+    let detailReadCount = 0;
+    const appThread = {
+      id: threadId,
+      createdAt: now,
+      cwd: workspacePath,
+      modelProvider: "gpt-5.5",
+      name: "Late rollout path",
+      preview: "Late rollout path",
+      source: "app",
+      status: { type: "notLoaded" },
+      updatedAt: now,
+    };
+    const appServer = {
+      onNotification() {
+        return () => undefined;
+      },
+      onRequest() {
+        return () => undefined;
+      },
+      readThread: vi.fn<() => Promise<unknown>>(async () => ({
+        ...appThread,
+        path: detailReadCount++ === 0 ? undefined : selectedPath,
+      })),
+    };
+    const app = createApp({
+      appServer: appServer as never,
+      codex: createMockCodex(),
+      workspacePath,
+    });
+
+    try {
+      const fallbackResponse = await app.request(`/v1/threads/${threadId}`);
+      const fallbackBody = await fallbackResponse.json();
+      expect(fallbackBody.messages.map((message: { content: string }) => message.content)).toEqual([
+        "old prompt",
+        "old answer",
+      ]);
+
+      await writeFile(selectedPath, rolloutLines("current prompt", "current answer"));
+      const selectedResponse = await app.request(`/v1/threads/${threadId}`);
+      const selectedBody = await selectedResponse.json();
+
+      expect(selectedResponse.status).toBe(200);
+      expect(selectedBody.messages.map((message: { content: string }) => message.content)).toEqual([
+        "current prompt",
+        "current answer",
+      ]);
+    } finally {
+      process.env.CODEX_HOME = previousCodexHome;
+    }
+  });
+
+  it("uses canonical app-server history instead of projecting paginated rollout records", async () => {
+    const workspacePath = await mkdtemp(join(tmpdir(), "codex-relay-workspace-"));
+    const codexHome = await mkdtemp(join(tmpdir(), "codex-relay-home-"));
+    const sessionsDir = join(codexHome, "sessions", "2026", "08", "26");
+    await mkdir(sessionsDir, { recursive: true });
+    const threadId = "app-thread-paginated-rollout";
+    const rolloutPath = join(
+      sessionsDir,
+      `rollout-2026-08-26T00-00-00-${threadId}_rollout-id.jsonl`,
+    );
+    await writeFile(
+      rolloutPath,
+      [
+        JSON.stringify({
+          payload: { history_mode: "paginated", id: threadId },
+          timestamp: "2026-08-26T00:00:00.000Z",
+          type: "session_meta",
+        }),
+        JSON.stringify({
+          payload: { message: "stale raw projection", type: "agent_message" },
+          timestamp: "2026-08-26T00:00:01.000Z",
+          type: "event_msg",
+        }),
+      ].join("\n"),
+    );
+    const previousCodexHome = process.env.CODEX_HOME;
+    process.env.CODEX_HOME = codexHome;
+    const now = Date.now() / 1000;
+    const canonicalThread = {
+      ...appServerHistoryThread({
+        id: threadId,
+        name: "Paginated history",
+        turns: [appServerTurn("turn-paginated", "canonical prompt", now)],
+        workspacePath,
+      }),
+      path: rolloutPath,
+    };
+    const readThread = vi.fn<
+      (_threadId: string, options?: { includeTurns?: boolean }) => Promise<unknown>
+    >(async (_threadId, options) => ({
+      ...canonicalThread,
+      turns: options?.includeTurns === false ? undefined : canonicalThread.turns,
+    }));
+    const appServer = {
+      onNotification() {
+        return () => undefined;
+      },
+      onRequest() {
+        return () => undefined;
+      },
+      readThread,
+    };
+    const app = createApp({
+      appServer: appServer as never,
+      codex: createMockCodex(),
+      workspacePath,
+    });
+
+    try {
+      const response = await app.request(`/v1/threads/${threadId}`);
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(readThread).toHaveBeenCalledTimes(2);
+      expect(body.messages.map((message: { content: string }) => message.content)).toEqual([
+        "canonical prompt",
+        "Reply: canonical prompt",
+      ]);
+      expect(body.messages).not.toContainEqual(
+        expect.objectContaining({ content: "stale raw projection" }),
+      );
     } finally {
       process.env.CODEX_HOME = previousCodexHome;
     }
@@ -7398,6 +8213,97 @@ describe("Codex Relay server routes", () => {
     expect(body).not.toHaveProperty("olderMessagesCursor");
   });
 
+  it("does not let a stale background history read overwrite a live completed item", async () => {
+    const workspacePath = await mkdtemp(join(tmpdir(), "codex-relay-workspace-"));
+    const notificationHandlers = new Set<(notification: unknown) => void>();
+    const now = Date.now() / 1000;
+    const runningThread = {
+      id: "app-thread-background-race",
+      createdAt: now,
+      cwd: workspacePath,
+      modelProvider: "gpt-5.5",
+      name: "Background race",
+      preview: "Background race",
+      source: "app",
+      status: { type: "active" },
+      updatedAt: now,
+    };
+    let resolveHistory!: (thread: unknown) => void;
+    const history = new Promise<unknown>((resolve) => {
+      resolveHistory = resolve;
+    });
+    const readThread = vi.fn<
+      (_threadId: string, options?: { includeTurns?: boolean }) => Promise<unknown>
+    >(async (_threadId, options) =>
+      options?.includeTurns === true ? history : Promise.resolve(runningThread),
+    );
+    const appServer = {
+      onNotification(handler: (notification: unknown) => void) {
+        notificationHandlers.add(handler);
+        return () => notificationHandlers.delete(handler);
+      },
+      onRequest() {
+        return () => undefined;
+      },
+      readThread,
+    };
+    const app = createApp({
+      appServer: appServer as never,
+      codex: createMockCodex(),
+      workspacePath,
+    });
+
+    const initialResponse = await app.request("/v1/threads/app-thread-background-race");
+    expect(initialResponse.status).toBe(200);
+    expect(readThread).toHaveBeenCalledWith("app-thread-background-race", {
+      includeTurns: true,
+    });
+
+    for (const handler of notificationHandlers) {
+      handler({
+        method: "item/completed",
+        params: {
+          item: {
+            id: "assistant-background-race",
+            text: "fresh live answer",
+            type: "agentMessage",
+          },
+          threadId: "app-thread-background-race",
+          turnId: "turn-background-race",
+        },
+      });
+    }
+    resolveHistory({
+      ...runningThread,
+      turns: [
+        {
+          id: "turn-background-race",
+          items: [
+            {
+              id: "assistant-background-race",
+              text: "stale snapshot answer",
+              type: "agentMessage",
+            },
+          ],
+          itemsView: "full",
+          status: { type: "completed" },
+          startedAt: now,
+          completedAt: now,
+        },
+      ],
+    });
+    await vi.waitFor(() => expect(readThread).toHaveBeenCalledTimes(2));
+    await Promise.resolve();
+
+    const settledResponse = await app.request("/v1/threads/app-thread-background-race");
+    const settledBody = await settledResponse.json();
+
+    expect(settledResponse.status).toBe(200);
+    expect(settledBody.messages).toEqual([
+      expect.objectContaining({ id: "assistant-background-race", content: "fresh live answer" }),
+    ]);
+  });
+
   it("streams run events for a known thread", async () => {
     const app = createApp({ codex: createMockCodex() });
 
@@ -7417,8 +8323,103 @@ describe("Codex Relay server routes", () => {
     expect(response.status).toBe(200);
     expect(response.headers.get("content-type")).toContain("text/event-stream");
     expect(body).toContain("thread.message.created");
-    expect(body).toContain("thread.message.delta");
     expect(body).toContain("streamed: Stream this");
+  });
+
+  it("uses the last completed SDK agent message as the final response", async () => {
+    let thread: CodexThread;
+    thread = {
+      id: null,
+      async run() {
+        return { finalResponse: "Final answer" };
+      },
+      async runStreamed() {
+        async function* events() {
+          thread.id = "sdk-final-thread";
+          yield { type: "thread.started", thread_id: "sdk-final-thread" };
+          yield {
+            type: "item.started",
+            item: {
+              id: "file-change",
+              type: "file_change",
+              changes: [],
+            },
+          };
+          yield {
+            type: "item.completed",
+            item: {
+              id: "file-change",
+              type: "file_change",
+              changes: [{ kind: "update", path: "src/example.ts" }],
+            },
+          };
+          yield {
+            type: "item.completed",
+            item: {
+              id: "todo-list",
+              type: "todo_list",
+              items: [{ completed: true, text: "Verify the response" }],
+            },
+          };
+          yield {
+            type: "item.completed",
+            item: { id: "commentary", type: "agent_message", text: "Working on it" },
+          };
+          yield {
+            type: "item.completed",
+            item: { id: "final", type: "agent_message", text: "Final answer" },
+          };
+          yield { type: "turn.completed" };
+        }
+
+        return { events: events() };
+      },
+    };
+    const codex: CodexClient = {
+      startThread: () => thread,
+      resumeThread: () => thread,
+    };
+    const app = createApp({ appServer: null, codex });
+
+    const createResponse = await app.request("/v1/threads", {
+      method: "POST",
+      body: JSON.stringify({ title: "SDK final response" }),
+      headers: { "content-type": "application/json" },
+    });
+    const created = await createResponse.json();
+    const response = await app.request(`/v1/threads/${created.thread.id}/runs/stream`, {
+      method: "POST",
+      body: JSON.stringify({ prompt: "Answer this" }),
+      headers: { "content-type": "application/json" },
+    });
+    await response.text();
+    const detailResponse = await app.request("/v1/threads/sdk-final-thread");
+    const detail = await detailResponse.json();
+
+    expect(
+      detail.messages.find((message: { role: string }) => message.role === "assistant"),
+    ).toMatchObject({
+      content: "Final answer",
+      role: "assistant",
+      state: "completed",
+    });
+    expect(detail.messages).toContainEqual(
+      expect.objectContaining({
+        content: "1 file changed: src/example.ts",
+        kind: "fileChange",
+        role: "tool",
+      }),
+    );
+    expect(detail.messages).toContainEqual(
+      expect.objectContaining({
+        content: "[x] Verify the response",
+        kind: "plan",
+        role: "status",
+      }),
+    );
+    expect(
+      detail.messages.filter((message: { id: string }) => message.id === "file-change"),
+    ).toHaveLength(1);
   });
 
   it("rejects invalid payloads with a structured error", async () => {

--- a/packages/codex-relay/test/codex-binary.test.ts
+++ b/packages/codex-relay/test/codex-binary.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { sep } from "node:path";
 
 import {
   resolveCodexAppServerMode,
@@ -49,18 +50,19 @@ describe("Codex app-server spawn resolution", () => {
     expect(mode).toEqual({ fallbackToStdio: false, mode: "stdio" });
   });
 
-  it("uses a shell for the default npm command on Windows", () => {
+  it("uses the packaged Codex CLI by default on Windows", () => {
     const spawnConfig = resolveCodexAppServerSpawn({
       env: {},
       platform: "win32",
     });
 
-    expect(spawnConfig).toEqual({
-      command: "codex",
-      args: ["app-server", "--listen", "stdio://"],
-      shell: true,
-      windowsHide: true,
-    });
+    expect(spawnConfig.command).toBe(process.execPath);
+    expect(spawnConfig.args.slice(1)).toEqual(["app-server", "--listen", "stdio://"]);
+    expect(spawnConfig.args[0]).toContain(
+      ["node_modules", "@openai", "codex", "bin", "codex.js"].join(sep),
+    );
+    expect(spawnConfig.shell).toBe(false);
+    expect(spawnConfig.windowsHide).toBe(true);
   });
 
   it("uses a shell for Windows command shims", () => {
@@ -91,27 +93,28 @@ describe("Codex app-server spawn resolution", () => {
     });
   });
 
-  it("spawns the command directly on POSIX platforms", () => {
+  it("uses the packaged Codex CLI by default on POSIX platforms", () => {
     const spawnConfig = resolveCodexAppServerSpawn({
       env: {},
       platform: "linux",
     });
 
-    expect(spawnConfig).toEqual({
-      command: "codex",
-      args: ["app-server", "--listen", "stdio://"],
-      shell: false,
-      windowsHide: false,
-    });
+    expect(spawnConfig.command).toBe(process.execPath);
+    expect(spawnConfig.args.slice(1)).toEqual(["app-server", "--listen", "stdio://"]);
+    expect(spawnConfig.args[0]).toContain(
+      ["node_modules", "@openai", "codex", "bin", "codex.js"].join(sep),
+    );
+    expect(spawnConfig.shell).toBe(false);
+    expect(spawnConfig.windowsHide).toBe(false);
   });
 
   it("listens on the shared Unix socket in shared mode", () => {
-    expect(resolveCodexSharedAppServerSpawn({ env: {}, platform: "linux" })).toEqual({
-      command: "codex",
-      args: ["app-server", "--listen", "unix://"],
-      shell: false,
-      windowsHide: false,
-    });
+    const spawnConfig = resolveCodexSharedAppServerSpawn({ env: {}, platform: "linux" });
+
+    expect(spawnConfig.command).toBe(process.execPath);
+    expect(spawnConfig.args.slice(1)).toEqual(["app-server", "--listen", "unix://"]);
+    expect(spawnConfig.shell).toBe(false);
+    expect(spawnConfig.windowsHide).toBe(false);
   });
 
   it("rejects unknown app-server modes", () => {
@@ -124,16 +127,14 @@ describe("Codex app-server spawn resolution", () => {
   });
 
   it("listens on a loopback WebSocket in shared mode on native Windows", () => {
-    expect(
-      resolveCodexSharedAppServerSpawn({
-        env: { CODEX_RELAY_APP_SERVER_MODE: "socket" },
-        platform: "win32",
-      }),
-    ).toEqual({
-      command: "codex",
-      args: ["app-server", "--listen", "ws://127.0.0.1:8788"],
-      shell: true,
-      windowsHide: true,
+    const spawnConfig = resolveCodexSharedAppServerSpawn({
+      env: { CODEX_RELAY_APP_SERVER_MODE: "socket" },
+      platform: "win32",
     });
+
+    expect(spawnConfig.command).toBe(process.execPath);
+    expect(spawnConfig.args.slice(1)).toEqual(["app-server", "--listen", "ws://127.0.0.1:8788"]);
+    expect(spawnConfig.shell).toBe(false);
+    expect(spawnConfig.windowsHide).toBe(true);
   });
 });

--- a/packages/codex-relay/test/codex.test.ts
+++ b/packages/codex-relay/test/codex.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+
+import { extractStreamText } from "../src/codex.js";
+
+describe("Codex SDK event compatibility", () => {
+  it("extracts the nested error from a failed turn", () => {
+    expect(
+      extractStreamText({
+        type: "turn.failed",
+        error: { message: "The Codex turn failed." },
+      }),
+    ).toBe("The Codex turn failed.");
+  });
+});

--- a/packages/codex-relay/test/live-mobile-stream-contract.test.ts
+++ b/packages/codex-relay/test/live-mobile-stream-contract.test.ts
@@ -49,11 +49,10 @@ liveDescribe("live mobile stream contract", () => {
     const thread = await appServer.startThread({
       approvalPolicy: "never",
       cwd: workspacePath,
-      experimentalRawEvents: false,
       model: null,
-      persistExtendedHistory: true,
       sandbox: "read-only",
       serviceTier: null,
+      threadSource: "codex-relay-test",
     });
 
     try {

--- a/packages/codex-relay/test/mobile-active-thread-selection.test.ts
+++ b/packages/codex-relay/test/mobile-active-thread-selection.test.ts
@@ -33,6 +33,17 @@ describe("mobile active thread refresh selection", () => {
       }),
     ).toBe("thread-fallback");
   });
+
+  it("replaces a cache-hydrated default with the first fresh server thread", () => {
+    expect(
+      activeThreadAfterRefresh({
+        currentActiveThreadId: "thread-stale-default",
+        missingActiveThreadRestored: false,
+        preferFirstThread: true,
+        threads: [threadSummary("thread-fresh-default"), threadSummary("thread-stale-default")],
+      }),
+    ).toBe("thread-fresh-default");
+  });
 });
 
 function threadSummary(id: string): ThreadSummary {

--- a/packages/codex-relay/test/mobile-steering-optimistic-state.test.ts
+++ b/packages/codex-relay/test/mobile-steering-optimistic-state.test.ts
@@ -49,6 +49,121 @@ describe("mobile optimistic queued-input steering state", () => {
       role: "user",
     });
   });
+
+  it("does not let a late thread snapshot replace a completed streamed message", () => {
+    const completedThread = {
+      ...threadSummary("thread-late-snapshot"),
+      state: "completed" as const,
+      updatedAt: "2026-06-06T00:00:03.000Z",
+    };
+    const staleThread = {
+      ...completedThread,
+      state: "running" as const,
+      updatedAt: "2026-06-06T00:00:01.000Z",
+    };
+    const completedMessage = {
+      ...chatMessage("assistant-late-snapshot", completedThread.id, "Hello world"),
+      role: "assistant" as const,
+      state: "completed" as const,
+      updatedAt: "2026-06-06T00:00:03.000Z",
+    };
+    const staleMessage = {
+      ...completedMessage,
+      content: "Hello",
+      state: "streaming" as const,
+      updatedAt: "2026-06-06T00:00:01.000Z",
+    };
+
+    const merged = mergeThreadDetailState(
+      {
+        thread: completedThread,
+        messages: [completedMessage],
+        pendingInputRequests: [],
+      },
+      { thread: staleThread, messages: [staleMessage], pendingInputRequests: [] },
+    );
+
+    expect(merged.thread).toMatchObject({ state: "completed" });
+    expect(merged.messages).toEqual([completedMessage]);
+  });
+
+  it("does not reopen a terminal thread whose message cache is still empty", () => {
+    const completedThread = {
+      ...threadSummary("thread-empty-terminal"),
+      state: "completed" as const,
+      updatedAt: "2026-06-06T00:00:03.000Z",
+    };
+    const staleRunningThread = {
+      ...completedThread,
+      state: "running" as const,
+      updatedAt: "2026-06-06T00:00:01.000Z",
+    };
+
+    const merged = mergeThreadDetailState(
+      { thread: completedThread, messages: [], pendingInputRequests: [] },
+      { thread: staleRunningThread, messages: [], pendingInputRequests: [] },
+    );
+
+    expect(merged.thread.state).toBe("completed");
+  });
+
+  it("sorts late-created messages by their server creation time", () => {
+    const thread = threadSummary("thread-message-order");
+    const newer = {
+      ...chatMessage("message-newer", thread.id, "newer"),
+      createdAt: "2026-06-06T00:00:02.000Z",
+    };
+    const older = {
+      ...chatMessage("message-older", thread.id, "older"),
+      createdAt: "2026-06-06T00:00:01.000Z",
+    };
+
+    expect(upsertMessage([newer], older).map((message) => message.id)).toEqual([
+      "message-older",
+      "message-newer",
+    ]);
+  });
+
+  it("does not regress a completed message when its creation event is replayed", () => {
+    const thread = threadSummary("thread-replayed-message");
+    const completed = {
+      ...chatMessage("assistant-replayed", thread.id, "Final answer"),
+      role: "assistant" as const,
+      state: "completed" as const,
+      updatedAt: "2026-06-06T00:00:03.000Z",
+    };
+    const replayedCreation = {
+      ...completed,
+      content: "",
+      state: "streaming" as const,
+      updatedAt: "2026-06-06T00:00:01.000Z",
+    };
+
+    expect(upsertMessage([completed], replayedCreation)).toEqual([completed]);
+  });
+
+  it("does not restore a local message after its canonical replacement arrives", () => {
+    const thread = threadSummary("thread-replacement-replay");
+    const localMessage = chatMessage("local-user", thread.id, "Keep one copy");
+    const canonicalMessage = {
+      ...chatMessage("canonical-user", thread.id, "Keep one copy"),
+      details: { replacesMessageId: localMessage.id },
+    };
+    const canonicalDetail = {
+      thread,
+      messages: [canonicalMessage],
+      pendingInputRequests: [],
+    };
+
+    expect(upsertMessage([canonicalMessage], localMessage)).toEqual([canonicalMessage]);
+    expect(
+      mergeThreadDetailState(canonicalDetail, {
+        thread,
+        messages: [localMessage],
+        pendingInputRequests: [],
+      }).messages,
+    ).toEqual([canonicalMessage]);
+  });
 });
 
 function threadSummary(id: string): ThreadSummary {

--- a/packages/codex-relay/test/mobile-stream-contract.test.ts
+++ b/packages/codex-relay/test/mobile-stream-contract.test.ts
@@ -2,7 +2,7 @@ import { mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { QueuedThreadInput } from "../src/api-schema.js";
+import type { QueuedThreadInput, StreamThreadRunEvent, ThreadSummary } from "../src/api-schema.js";
 
 import { createApp } from "../src/app.js";
 import {
@@ -18,6 +18,7 @@ import {
   completeThreadRunSession,
   createThreadRunSseDispatcher,
   handleThreadRunStreamEvent,
+  reconcileThreadRunEventAfterTerminal,
   threadRunStreamEventTypes,
 } from "../../../apps/mobile/src/lib/thread-run-stream.js";
 
@@ -308,8 +309,8 @@ describe("mobile stream contract", () => {
     const now = Date.now() / 1000;
     const startTurn = vi.fn<(params: unknown) => Promise<unknown>>(async () => {
       queueMicrotask(() => {
-        for (const handler of notificationHandlers) {
-          handler({
+        const notifications = [
+          {
             method: "item/agentMessage/delta",
             params: {
               delta: "hello",
@@ -317,16 +318,16 @@ describe("mobile stream contract", () => {
               threadId: "app-thread-provider-contract",
               turnId: "turn-provider-contract",
             },
-          });
-          handler({
+          },
+          {
             method: "item/completed",
             params: {
               item: { id: "assistant-provider-contract", text: "hello", type: "agentMessage" },
               threadId: "app-thread-provider-contract",
               turnId: "turn-provider-contract",
             },
-          });
-          handler({
+          },
+          {
             method: "turn/completed",
             params: {
               threadId: "app-thread-provider-contract",
@@ -340,7 +341,12 @@ describe("mobile stream contract", () => {
                 durationMs: 1,
               },
             },
-          });
+          },
+        ];
+        for (const notification of notifications) {
+          for (const handler of notificationHandlers) {
+            handler(notification);
+          }
         }
       });
       return {
@@ -458,7 +464,135 @@ describe("mobile stream contract", () => {
     expect(setQueuedInputs).toHaveBeenCalledWith("thread-terminal", []);
     expect(refreshUsageStatus).toHaveBeenCalledWith("thread-terminal");
   });
+
+  it("applies authoritative snapshots after terminal without reopening the thread", () => {
+    const failedThread = threadSummary("thread-post-terminal", "failed");
+    const terminalEvent = {
+      type: "thread.state.changed",
+      thread: failedThread,
+    } satisfies StreamThreadRunEvent;
+    const staleRunningThread = {
+      ...failedThread,
+      lastError: undefined,
+      state: "running" as const,
+      updatedAt: "2026-04-29T00:00:01.000Z",
+    };
+    const errorMessageEvent = {
+      type: "thread.message.created",
+      thread: staleRunningThread,
+      message: {
+        content: "The turn failed.",
+        createdAt: "2026-04-29T00:00:01.000Z",
+        id: "error-post-terminal",
+        kind: "chat",
+        role: "error",
+        state: "failed",
+        threadId: failedThread.id,
+        updatedAt: "2026-04-29T00:00:01.000Z",
+      },
+    } satisfies StreamThreadRunEvent;
+    const lateItemEvent = {
+      type: "thread.message.completed",
+      thread: staleRunningThread,
+      message: {
+        content: "late command output",
+        createdAt: "2026-04-29T00:00:02.000Z",
+        id: "command-post-terminal",
+        kind: "commandExecution",
+        role: "tool",
+        state: "completed",
+        threadId: failedThread.id,
+        updatedAt: "2026-04-29T00:00:02.000Z",
+      },
+    } satisfies StreamThreadRunEvent;
+    const errorEvent = {
+      type: "thread.error",
+      thread: staleRunningThread,
+      error: { code: "codex_run_failed", message: "The turn failed." },
+    } satisfies StreamThreadRunEvent;
+
+    replaceThreads([failedThread]);
+    setActiveThread(failedThread.id);
+    const consumed = consumeTerminalSequenceAsMobileChatScreen([
+      terminalEvent,
+      errorMessageEvent,
+      errorEvent,
+      lateItemEvent,
+      { type: "thread.state.changed", thread: staleRunningThread },
+      {
+        type: "thread.message.delta",
+        threadId: failedThread.id,
+        messageId: "command-post-terminal",
+        delta: "stale",
+      },
+    ]);
+
+    expect(consumed.appliedEventTypes).toEqual([
+      "thread.state.changed",
+      "thread.message.created",
+      "thread.error",
+      "thread.message.completed",
+    ]);
+    expect(consumed.terminalThreadIds).toEqual([failedThread.id]);
+    expect(
+      consumed.appliedEvents
+        .filter((event) => "thread" in event && event.thread)
+        .map((event) => ("thread" in event ? event.thread?.state : undefined)),
+    ).toEqual(["failed", "failed", "failed", "failed"]);
+    expect(
+      (chatStore$.messagesByThreadId[failedThread.id].peek() ?? []).map((message) => [
+        message.role,
+        message.content,
+      ]),
+    ).toEqual([
+      ["error", "The turn failed."],
+      ["tool", "late command output"],
+    ]);
+  });
 });
+
+function threadSummary(id: string, state: ThreadSummary["state"]): ThreadSummary {
+  return {
+    createdAt: "2026-04-29T00:00:00.000Z",
+    id,
+    lastError: state === "failed" ? "The turn failed." : undefined,
+    messageCount: 0,
+    state,
+    title: id,
+    updatedAt: "2026-04-29T00:00:00.000Z",
+  };
+}
+
+function consumeTerminalSequenceAsMobileChatScreen(events: StreamThreadRunEvent[]) {
+  const appliedEvents: StreamThreadRunEvent[] = [];
+  const appliedEventTypes: StreamThreadRunEvent["type"][] = [];
+  const terminalThreadIds: string[] = [];
+  let terminalEvent: StreamThreadRunEvent | undefined;
+
+  for (const event of events) {
+    const reconciledEvent = reconcileThreadRunEventAfterTerminal(event, terminalEvent);
+    if (!reconciledEvent) {
+      continue;
+    }
+    handleThreadRunStreamEvent(reconciledEvent, {
+      fallbackThreadId: "thread-post-terminal",
+      applyEvent(streamEvent) {
+        appliedEvents.push(streamEvent);
+        appliedEventTypes.push(streamEvent.type);
+        applyStreamEvent(streamEvent);
+      },
+      onTerminal(threadId, streamEvent) {
+        if (terminalEvent) {
+          return;
+        }
+        terminalEvent = streamEvent;
+        terminalThreadIds.push(threadId);
+      },
+    });
+  }
+
+  return { appliedEvents, appliedEventTypes, terminalThreadIds };
+}
 
 function consumeAsMobileChatStream(body: string, threadId: string) {
   const errors: Error[] = [];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -312,6 +312,9 @@ importers:
       '@noble/hashes':
         specifier: 2.2.0
         version: 2.2.0
+      '@openai/codex':
+        specifier: 0.149.1
+        version: 0.149.1
       '@openai/codex-sdk':
         specifier: 0.149.1
         version: 0.149.1

--- a/scripts/mobile-release-version.test.mjs
+++ b/scripts/mobile-release-version.test.mjs
@@ -101,3 +101,19 @@ test("defines independent npm and mobile version commands", () => {
   assert.match(releaseWorkflow, /changeset-release\/mobile-main/);
   assert.doesNotMatch(releaseWorkflow, /changesets\/action/);
 });
+
+test("waits for the relay package release before preparing the mobile OTA", () => {
+  const releaseWorkflow = readFileSync(
+    new URL("../.github/workflows/release.yml", import.meta.url),
+    "utf8",
+  );
+
+  assert.match(
+    releaseWorkflow,
+    /if: steps\.mobile-release-plan\.outputs\.deploy == 'true' && steps\.mobile-release-plan\.outputs\.relay-package-version == ''/,
+  );
+  assert.match(
+    releaseWorkflow,
+    /if \(process\.env\.MOBILE_RELEASE_VERSION && !process\.env\.RELAY_RELEASE_VERSION\)/,
+  );
+});


### PR DESCRIPTION
## Summary

- Pin the app-server CLI to the exact Codex version bundled by `@openai/codex-sdk`, and keep the updater workflow pinning both packages together.
- Align the relay with Codex 0.149 app-server behavior: completion summaries, stable item upserts, logical thread IDs versus rollout paths, paginated revert, bounded resume, reconnect reconciliation, async agent delivery, string request IDs, input resolution, source filtering, and recency ordering.
- Make canonical full history authoritative while preserving summary-only cached detail, invalidate history on `thread/reverted` or rollout path changes, and fence stale background reads against live completion events.
- Prevent mobile GET/SSE, terminal, thread-selection, hydration, message-order, and canonical user-message replacement races from restoring old or partial conversation state.
- Bring the SDK fallback in line with the public stream contract for final agent messages, structured items, nested failures, and the actual `thread.started` ID.
- Require the relay package version bundled with the mobile release before mounting the app, with a fail-closed update screen, retry, and recovery to another relay.
- Publish the relay npm release before preparing the dependent mobile OTA so the app requires the newly published relay version.

## Upstream references

- [Codex 0.145.0 to 0.149.1 comparison](https://github.com/openai/codex/compare/rust-v0.145.0...rust-v0.149.1)
- [Include final agent message in turn completion summaries](https://github.com/openai/codex/pull/34777)
- [Support incremental replay of updated items](https://github.com/openai/codex/pull/35013)
- [Distinguish rollout IDs from thread IDs](https://github.com/openai/codex/pull/38127)
- [Resolve paginated history by rollout ID](https://github.com/openai/codex/pull/38244)
- [Add thread revert notifications](https://github.com/openai/codex/pull/38440)

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm test` — 311 passed, 4 skipped
- `pnpm test:release` — 15 passed
- `pnpm typecheck`
- `pnpm lint` — 0 warnings
- iPhone 17 Pro simulator — verified the fail-closed version screen, update command, retry, and alternate-relay action
- Packaged CLI: `codex-cli 0.149.1`