### PR TITLE
fix: restore mobile chat streaming after SDK upgrade

### DIFF
--- a/.changeset/bright-streams-resume.md
+++ b/.changeset/bright-streams-resume.md
@@ -1,0 +1,5 @@
+---
+"codex-relay": patch
+---
+
+Resume persisted app-server threads before starting turns so mobile clients continue receiving streamed responses after relay reconnections.

--- a/packages/codex-relay/src/app-server.ts
+++ b/packages/codex-relay/src/app-server.ts
@@ -311,6 +311,10 @@ export class CodexAppServerClient {
     return this.activeMode;
   }
 
+  isThreadSubscribed(threadId: string) {
+    return this.subscribedThreadIds.has(threadId);
+  }
+
   initialize() {
     return this.ensureInitialized();
   }

--- a/packages/codex-relay/src/app.ts
+++ b/packages/codex-relay/src/app.ts
@@ -3742,6 +3742,11 @@ async function resumeAppServerThreadIfNeeded(
   input: QueuedThreadInput,
   runtime: ReturnType<typeof resolveAppServerRuntime>,
 ) {
+  if (appServer.isThreadSubscribed?.(threadId) === false) {
+    await resumeAppServerThread(appServer, threadId, input, runtime);
+    return;
+  }
+
   if (typeof appServer.readThread !== "function") {
     return;
   }

--- a/packages/codex-relay/test/app.test.ts
+++ b/packages/codex-relay/test/app.test.ts
@@ -5918,19 +5918,20 @@ describe("Codex Relay server routes", () => {
     expect(body).toContain('"state":"completed"');
   });
 
-  it("resumes not-loaded app-server threads before continuing a streamed turn", async () => {
+  it("resumes persisted app-server threads when the client is not subscribed", async () => {
     const workspacePath = await mkdtemp(join(tmpdir(), "codex-relay-workspace-"));
     const notificationHandlers = new Set<(notification: unknown) => void>();
     const now = Date.now() / 1000;
+    let subscribed = false;
     const appThread = {
-      id: "app-thread-not-loaded",
+      id: "app-thread-unsubscribed",
       createdAt: now,
       cwd: workspacePath,
       modelProvider: "gpt-5.5",
       name: "Past thread",
       preview: "First message",
       source: "app",
-      status: { type: "notLoaded" },
+      status: { type: "idle" },
       turns: [
         {
           id: "turn-existing",
@@ -5957,13 +5958,17 @@ describe("Codex Relay server routes", () => {
       onRequest() {
         return () => undefined;
       },
+      isThreadSubscribed: vi.fn<() => boolean>(() => subscribed),
       readThread: vi.fn<() => Promise<unknown>>(async () => appThread),
-      resumeThread: vi.fn<() => Promise<unknown>>(async () => ({
-        ...appThread,
-        status: { type: "idle" },
-      })),
+      resumeThread: vi.fn<() => Promise<unknown>>(async () => {
+        subscribed = true;
+        return appThread;
+      }),
       startThread: vi.fn<() => Promise<unknown>>(async () => appThread),
       startTurn: vi.fn<() => Promise<unknown>>(async () => {
+        if (!subscribed) {
+          throw new Error("Expected thread/resume before turn/start.");
+        }
         queueMicrotask(() => {
           for (const handler of notificationHandlers) {
             handler({
@@ -5971,14 +5976,14 @@ describe("Codex Relay server routes", () => {
               params: {
                 delta: "continued reply",
                 itemId: "assistant-continued",
-                threadId: "app-thread-not-loaded",
+                threadId: "app-thread-unsubscribed",
                 turnId: "turn-continued",
               },
             });
             handler({
               method: "turn/completed",
               params: {
-                threadId: "app-thread-not-loaded",
+                threadId: "app-thread-unsubscribed",
                 turn: {
                   id: "turn-continued",
                   items: [],
@@ -6007,7 +6012,7 @@ describe("Codex Relay server routes", () => {
       workspacePath,
     });
 
-    const response = await app.request("/v1/threads/app-thread-not-loaded/runs/stream", {
+    const response = await app.request("/v1/threads/app-thread-unsubscribed/runs/stream", {
       method: "POST",
       body: JSON.stringify({ prompt: "Continue this" }),
       headers: { "content-type": "application/json" },
@@ -6017,7 +6022,7 @@ describe("Codex Relay server routes", () => {
     expect(response.status).toBe(200);
     expect(appServer.resumeThread).toHaveBeenCalledWith(
       expect.objectContaining({
-        threadId: "app-thread-not-loaded",
+        threadId: "app-thread-unsubscribed",
       }),
     );
     expect(appServer.startTurn).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
## Summary

- Resume persisted app-server threads before `turn/start` when the current client connection is not subscribed.
- Keep the existing `notLoaded` fallback for partial and legacy app-server clients.
- Add a regression test for an `idle` persisted thread on a fresh, unsubscribed connection.
- Add a patch changeset for the published `codex-relay` package.

The Codex 0.149.1 app-server can return a persisted thread as `idle` from StateDb without subscribing the new connection to that thread. The relay previously treated the persisted status as connection readiness, so `turn/start` ran without the relay receiving message delta or completion notifications and mobile chat streaming remained pending.

## Validation

- [x] `pnpm test` — 313 passed, 4 skipped
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm exec changeset status`
- [x] Live app-server close/reconnect continuation scenario
- [x] iPhone 17 Pro simulator: restart relay, continue a persisted idle thread, and stream a 60-line response through completion

## Notes

- No mobile UI or configuration files are changed.
- Existing Hot Updater work remains isolated in PR #83.