### PR TITLE
fix: render mobile chat deltas immediately

### DIFF
--- a/.changeset/quick-deltas-render.md
+++ b/.changeset/quick-deltas-render.md
@@ -1,0 +1,5 @@
+---
+"@codex-relay/mobile": patch
+---
+
+Render assistant text deltas immediately instead of revealing the full response after completion.

--- a/apps/mobile/src/components/chat/MessageBubble.tsx
+++ b/apps/mobile/src/components/chat/MessageBubble.tsx
@@ -31,6 +31,7 @@ import { hapticSelection } from "@/lib/haptics";
 
 import { PromptMarkdownText } from "./PromptMarkdownText";
 import { ProtocolActivityCard } from "./ProtocolActivityCard";
+import { messageSegmentRenderKey } from "./message-segment-key";
 import type { WorkspaceMarkdownPreviewTarget } from "./workspace-preview/markdown-target";
 
 const DATA_URI_PATTERN = /data:[^;\s]+;base64,[A-Za-z0-9+/=\n\r]+/g;
@@ -343,10 +344,10 @@ export const MessageBubble = memo(function MessageBubble({
             <ThemedText type="code" themeColor="textSecondary" style={styles.assistantLabel}>
               Codex
             </ThemedText>
-            {markdownSegments.map((segment) =>
+            {markdownSegments.map((segment, index) =>
               segment.kind === "code" ? (
                 <HighlightedCodeBlock
-                  key={`code-${segment.language}-${segment.code}`}
+                  key={messageSegmentRenderKey(segment, index)}
                   code={segment.code}
                   deferHighlight={message.state === "streaming"}
                   language={segment.language}
@@ -354,11 +355,12 @@ export const MessageBubble = memo(function MessageBubble({
               ) : (
                 <EnrichedMarkdownText
                   allowFontScaling={false}
-                  key={`markdown-${segment.content}`}
+                  key={messageSegmentRenderKey(segment, index)}
                   maxFontSizeMultiplier={1}
                   markdown={segment.content.trimEnd() || " "}
                   selectable
-                  streamingAnimation={message.state === "streaming"}
+                  // Tiny Codex deltas restart the native fade before intermediate text is presented.
+                  streamingAnimation={false}
                   markdownStyle={assistantMarkdownStyle}
                 />
               ),

--- a/apps/mobile/src/components/chat/message-segment-key.test.ts
+++ b/apps/mobile/src/components/chat/message-segment-key.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+
+import { messageSegmentRenderKey } from "./message-segment-key";
+
+describe("messageSegmentRenderKey", () => {
+  it("keeps a streaming Markdown segment mounted as its content grows", () => {
+    const initialSegment = { content: "Hello", kind: "markdown" as const };
+    const appendedSegment = { content: "Hello world", kind: "markdown" as const };
+
+    expect(messageSegmentRenderKey(initialSegment, 0)).toBe(
+      messageSegmentRenderKey(appendedSegment, 0),
+    );
+  });
+
+  it("changes identity when the renderer kind changes at the same position", () => {
+    expect(messageSegmentRenderKey({ kind: "markdown" }, 0)).not.toBe(
+      messageSegmentRenderKey({ kind: "code" }, 0),
+    );
+  });
+});

--- a/apps/mobile/src/components/chat/message-segment-key.ts
+++ b/apps/mobile/src/components/chat/message-segment-key.ts
@@ -1,0 +1,3 @@
+export function messageSegmentRenderKey(segment: { kind: "code" | "markdown" }, index: number) {
+  return `${segment.kind}-${index}`;
+}


### PR DESCRIPTION
## Summary

- keep assistant Markdown/code segment identity stable while streamed content grows
- disable the native Markdown tail fade that continuously restarts on the SDK's tiny text deltas
- add a focused regression test and a mobile patch changeset

## Root cause

Codex app-server still emits `item/agentMessage/delta` events continuously (typically 1–3 characters). The mobile renderer keyed Markdown segments by their full content, remounting the native view for every delta. Its 200 ms streaming fade was also restarted by each tiny update, so intermediate text remained hidden until the message completed and the animation was disabled. Stable segment keys plus immediate native rendering restore visible progressive updates.

## Validation

- `pnpm --filter @codex-relay/mobile exec vitest run src/components/chat/message-segment-key.test.ts`
- `pnpm test` (313 passed, 4 skipped)
- `pnpm typecheck`
- `pnpm lint`
- `pnpm exec changeset status`
- iOS simulator diagnosis: confirmed the pre-fix full-response reveal while app-server emitted continuous 1–3 character deltas; simulator input automation became unresponsive during the final post-fix replay, so that replay was not counted as a pass
