### PR TITLE
fix: preserve progressive mobile chat rendering

### DIFF
--- a/.changeset/bright-streams-arrive.md
+++ b/.changeset/bright-streams-arrive.md
@@ -2,4 +2,4 @@
 "codex-relay": patch
 ---
 
-Create assistant messages before forwarding delta-first app-server streams so mobile clients render responses progressively.
+Keep started assistant messages in a streaming state and create missing messages before forwarding app-server deltas so mobile clients render responses progressively.

--- a/.changeset/bright-streams-arrive.md
+++ b/.changeset/bright-streams-arrive.md
@@ -2,4 +2,4 @@
 "codex-relay": patch
 ---
 
-Keep started assistant messages in a streaming state and create missing messages before forwarding app-server deltas so mobile clients render responses progressively.
+Keep started assistant messages in a streaming state, create missing messages before forwarding app-server deltas, and preserve whitespace-only deltas such as line breaks.

--- a/.changeset/bright-streams-arrive.md
+++ b/.changeset/bright-streams-arrive.md
@@ -1,0 +1,5 @@
+---
+"codex-relay": patch
+---
+
+Create assistant messages before forwarding delta-first app-server streams so mobile clients render responses progressively.

--- a/.changeset/soft-breaks-stream.md
+++ b/.changeset/soft-breaks-stream.md
@@ -2,4 +2,4 @@
 "@codex-relay/mobile": patch
 ---
 
-Preserve trailing Markdown whitespace and code-block newlines while assistant messages stream.
+Deliver iOS LAN stream callbacks progressively on the main queue, and preserve trailing Markdown whitespace and code-block newlines while assistant messages stream.

--- a/.changeset/soft-breaks-stream.md
+++ b/.changeset/soft-breaks-stream.md
@@ -1,0 +1,5 @@
+---
+"@codex-relay/mobile": patch
+---
+
+Preserve trailing Markdown whitespace and code-block newlines while assistant messages stream.

--- a/apps/mobile/src/components/chat/MessageBubble.tsx
+++ b/apps/mobile/src/components/chat/MessageBubble.tsx
@@ -32,6 +32,10 @@ import { hapticSelection } from "@/lib/haptics";
 import { PromptMarkdownText } from "./PromptMarkdownText";
 import { ProtocolActivityCard } from "./ProtocolActivityCard";
 import { messageSegmentRenderKey } from "./message-segment-key";
+import {
+  messageCodeContentForRender,
+  messageMarkdownContentForRender,
+} from "./message-markdown-content";
 import type { WorkspaceMarkdownPreviewTarget } from "./workspace-preview/markdown-target";
 
 const DATA_URI_PATTERN = /data:[^;\s]+;base64,[A-Za-z0-9+/=\n\r]+/g;
@@ -357,7 +361,7 @@ export const MessageBubble = memo(function MessageBubble({
                   allowFontScaling={false}
                   key={messageSegmentRenderKey(segment, index)}
                   maxFontSizeMultiplier={1}
-                  markdown={segment.content.trimEnd() || " "}
+                  markdown={messageMarkdownContentForRender(segment.content)}
                   selectable
                   // Tiny Codex deltas restart the native fade before intermediate text is presented.
                   streamingAnimation={false}
@@ -972,7 +976,7 @@ function parseMarkdownSegments(markdown: string): MarkdownSegment[] {
     if (fenceMatch) {
       if (isInCodeBlock) {
         segments.push({
-          code: trimCodeFenceContent(codeLines.join("\n")),
+          code: messageCodeContentForRender(codeLines.join("\n")),
           kind: "code",
           language: codeLanguage,
         });
@@ -1003,7 +1007,7 @@ function parseMarkdownSegments(markdown: string): MarkdownSegment[] {
 
   if (isInCodeBlock) {
     segments.push({
-      code: trimCodeFenceContent(codeLines.join("\n")),
+      code: messageCodeContentForRender(codeLines.join("\n")),
       kind: "code",
       language: codeLanguage,
     });
@@ -1017,10 +1021,6 @@ function parseMarkdownSegments(markdown: string): MarkdownSegment[] {
   }
 
   return segments.length > 0 ? segments : [{ content: markdown, kind: "markdown" }];
-}
-
-function trimCodeFenceContent(code: string) {
-  return code.replace(/^\n/, "").replace(/\n$/, "");
 }
 
 function normalizeCodeLanguage(value: string) {

--- a/apps/mobile/src/components/chat/message-markdown-content.test.ts
+++ b/apps/mobile/src/components/chat/message-markdown-content.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  messageCodeContentForRender,
+  messageMarkdownContentForRender,
+} from "./message-markdown-content";
+
+describe("messageMarkdownContentForRender", () => {
+  it.each([
+    ["soft break", "first\n"],
+    ["blank line", "first\n\n"],
+    ["hard break spaces", "first  "],
+    ["list indentation", "- parent\n  "],
+  ])("preserves trailing Markdown syntax while streaming: %s", (_name, content) => {
+    expect(messageMarkdownContentForRender(content)).toBe(content);
+  });
+
+  it("keeps an empty streaming message renderable", () => {
+    expect(messageMarkdownContentForRender("")).toBe(" ");
+  });
+});
+
+describe("messageCodeContentForRender", () => {
+  it("preserves incomplete fenced-code newlines while streaming", () => {
+    expect(messageCodeContentForRender("const first = 1;\n\n")).toBe("const first = 1;\n\n");
+  });
+});

--- a/apps/mobile/src/components/chat/message-markdown-content.ts
+++ b/apps/mobile/src/components/chat/message-markdown-content.ts
@@ -1,0 +1,7 @@
+export function messageMarkdownContentForRender(content: string) {
+  return content || " ";
+}
+
+export function messageCodeContentForRender(content: string) {
+  return content;
+}

--- a/packages/codex-relay/src/app.ts
+++ b/packages/codex-relay/src/app.ts
@@ -4075,11 +4075,27 @@ async function streamRunningAppServerThread(input: {
               return;
             }
             if (!input.messagesByThreadId.get(input.threadId)?.some((item) => item.id === itemId)) {
-              appendMessageWithId(input.messagesByThreadId, input.threadId, itemId, {
-                role: "assistant",
-                content: "",
-                state: "streaming",
-                turnId: firstString(params, ["turnId"]) ?? activeTurnId,
+              const createdMessage = appendMessageWithId(
+                input.messagesByThreadId,
+                input.threadId,
+                itemId,
+                {
+                  role: "assistant",
+                  content: "",
+                  state: "streaming",
+                  turnId: firstString(params, ["turnId"]) ?? activeTurnId,
+                },
+              );
+              threadSummary = updateThread(
+                input.threads,
+                input.messagesByThreadId,
+                input.threadId,
+                { state: "running" },
+              );
+              sendSse(input.controller, input.encoder, input.secureSession, {
+                type: "thread.message.created",
+                thread: threadSummary,
+                message: createdMessage,
               });
             }
             const isAsyncAgentMessage = asyncAgentMessageIds.has(itemId);
@@ -4828,11 +4844,27 @@ async function runAppServerPromptStreamed(input: {
               return;
             }
             if (!input.messagesByThreadId.get(activeThreadId)?.some((item) => item.id === itemId)) {
-              appendMessageWithId(input.messagesByThreadId, activeThreadId, itemId, {
-                role: "assistant",
-                content: "",
-                state: "streaming",
-                turnId: firstString(params, ["turnId"]) ?? activeTurnId,
+              const createdMessage = appendMessageWithId(
+                input.messagesByThreadId,
+                activeThreadId,
+                itemId,
+                {
+                  role: "assistant",
+                  content: "",
+                  state: "streaming",
+                  turnId: firstString(params, ["turnId"]) ?? activeTurnId,
+                },
+              );
+              threadSummary = updateThread(
+                input.threads,
+                input.messagesByThreadId,
+                activeThreadId,
+                { state: "running" },
+              );
+              sendSse(input.controller, input.encoder, input.secureSession, {
+                type: "thread.message.created",
+                thread: threadSummary,
+                message: createdMessage,
               });
             }
             const isAsyncAgentMessage = asyncAgentMessageIds.has(itemId);

--- a/packages/codex-relay/src/app.ts
+++ b/packages/codex-relay/src/app.ts
@@ -4075,7 +4075,7 @@ async function streamRunningAppServerThread(input: {
           case "item/agentMessage/delta": {
             observedTurnActivity = true;
             const itemId = firstString(params, ["itemId"]);
-            const delta = firstString(params, ["delta"]);
+            const delta = streamDelta(params);
             if (!itemId || !delta) {
               return;
             }
@@ -4849,7 +4849,7 @@ async function runAppServerPromptStreamed(input: {
           }
           case "item/agentMessage/delta": {
             const itemId = firstString(params, ["itemId"]);
-            const delta = firstString(params, ["delta"]);
+            const delta = streamDelta(params);
             if (!itemId || !delta) {
               return;
             }
@@ -8844,6 +8844,11 @@ function firstString(record: Record<string, unknown> | undefined, keys: string[]
     }
   }
   return undefined;
+}
+
+function streamDelta(record: Record<string, unknown> | undefined) {
+  const value = record?.delta;
+  return typeof value === "string" && value.length > 0 ? value : undefined;
 }
 
 function firstNumber(record: Record<string, unknown> | undefined, keys: string[]) {

--- a/packages/codex-relay/src/app.ts
+++ b/packages/codex-relay/src/app.ts
@@ -4032,7 +4032,7 @@ async function streamRunningAppServerThread(input: {
             if (!item || typeof item !== "object") {
               return;
             }
-            const message = upsertAppServerItemMessage(
+            let message = upsertAppServerItemMessage(
               input.messagesByThreadId,
               input.threadId,
               firstString(params, ["turnId"]) ?? activeTurnId,
@@ -4040,6 +4040,11 @@ async function streamRunningAppServerThread(input: {
             );
             if (!message) {
               return;
+            }
+            if (notification.method === "item/started") {
+              message = updateMessage(input.messagesByThreadId, input.threadId, message.id, {
+                state: "streaming",
+              });
             }
             const isAsyncAgentMessage = isAsyncAppServerAgentMessage(item as AppServerThreadItem);
             if (isAsyncAgentMessage) {
@@ -4802,7 +4807,7 @@ async function runAppServerPromptStreamed(input: {
               return;
             }
             const turnId = firstString(params, ["turnId"]) ?? activeTurnId;
-            const message = upsertAppServerItemMessage(
+            let message = upsertAppServerItemMessage(
               input.messagesByThreadId,
               activeThreadId,
               turnId,
@@ -4810,6 +4815,11 @@ async function runAppServerPromptStreamed(input: {
             );
             if (!message) {
               return;
+            }
+            if (notification.method === "item/started") {
+              message = updateMessage(input.messagesByThreadId, activeThreadId, message.id, {
+                state: "streaming",
+              });
             }
             const isAsyncAgentMessage = isAsyncAppServerAgentMessage(item as AppServerThreadItem);
             if (isAsyncAgentMessage) {

--- a/packages/codex-relay/test/mobile-stream-contract.test.ts
+++ b/packages/codex-relay/test/mobile-stream-contract.test.ts
@@ -76,6 +76,14 @@ describe("mobile stream contract", () => {
               },
             },
             {
+              method: "item/started",
+              params: {
+                item: { id: "assistant-mobile-contract", text: "", type: "agentMessage" },
+                threadId: "app-thread-mobile-contract",
+                turnId: "turn-mobile-contract",
+              },
+            },
+            {
               method: "item/agentMessage/delta",
               params: {
                 delta: "hi",
@@ -163,6 +171,9 @@ describe("mobile stream contract", () => {
     );
     expect(assistantCreatedIndex).toBeGreaterThan(-1);
     expect(assistantCreatedIndex).toBeLessThan(assistantDeltaIndex);
+    expect(consumed.events[assistantCreatedIndex]).toMatchObject({
+      message: { state: "streaming" },
+    });
     expect(consumed.eventTypes).toContain("thread.message.delta");
     expect(consumed.terminalThreadIds).toContain("app-thread-mobile-contract");
 

--- a/packages/codex-relay/test/mobile-stream-contract.test.ts
+++ b/packages/codex-relay/test/mobile-stream-contract.test.ts
@@ -58,12 +58,12 @@ describe("mobile stream contract", () => {
       })),
       startTurn: vi.fn<() => Promise<unknown>>(async () => {
         queueMicrotask(() => {
-          for (const handler of notificationHandlers) {
-            handler({
+          const notifications = [
+            {
               method: "thread/status/changed",
               params: { status: { type: "active" }, threadId: "app-thread-mobile-contract" },
-            });
-            handler({
+            },
+            {
               method: "turn/started",
               params: {
                 threadId: "app-thread-mobile-contract",
@@ -74,16 +74,8 @@ describe("mobile stream contract", () => {
                   completedAt: null,
                 },
               },
-            });
-            handler({
-              method: "item/started",
-              params: {
-                item: { id: "assistant-mobile-contract", text: "", type: "agentMessage" },
-                threadId: "app-thread-mobile-contract",
-                turnId: "turn-mobile-contract",
-              },
-            });
-            handler({
+            },
+            {
               method: "item/agentMessage/delta",
               params: {
                 delta: "hi",
@@ -91,20 +83,20 @@ describe("mobile stream contract", () => {
                 threadId: "app-thread-mobile-contract",
                 turnId: "turn-mobile-contract",
               },
-            });
-            handler({
+            },
+            {
               method: "item/completed",
               params: {
                 item: { id: "assistant-mobile-contract", text: "hi", type: "agentMessage" },
                 threadId: "app-thread-mobile-contract",
                 turnId: "turn-mobile-contract",
               },
-            });
-            handler({
+            },
+            {
               method: "thread/status/changed",
               params: { status: { type: "idle" }, threadId: "app-thread-mobile-contract" },
-            });
-            handler({
+            },
+            {
               method: "turn/completed",
               params: {
                 threadId: "app-thread-mobile-contract",
@@ -118,7 +110,12 @@ describe("mobile stream contract", () => {
                   durationMs: 1,
                 },
               },
-            });
+            },
+          ];
+          for (const notification of notifications) {
+            for (const handler of notificationHandlers) {
+              handler(notification);
+            }
           }
         });
         return {
@@ -156,6 +153,16 @@ describe("mobile stream contract", () => {
 
     const consumed = consumeAsMobileChatStream(body, "app-thread-mobile-contract");
     expect(consumed.errors).toEqual([]);
+    const assistantCreatedIndex = consumed.events.findIndex(
+      (event) =>
+        event.type === "thread.message.created" && event.message.id === "assistant-mobile-contract",
+    );
+    const assistantDeltaIndex = consumed.events.findIndex(
+      (event) =>
+        event.type === "thread.message.delta" && event.messageId === "assistant-mobile-contract",
+    );
+    expect(assistantCreatedIndex).toBeGreaterThan(-1);
+    expect(assistantCreatedIndex).toBeLessThan(assistantDeltaIndex);
     expect(consumed.eventTypes).toContain("thread.message.delta");
     expect(consumed.terminalThreadIds).toContain("app-thread-mobile-contract");
 
@@ -596,10 +603,12 @@ function consumeTerminalSequenceAsMobileChatScreen(events: StreamThreadRunEvent[
 
 function consumeAsMobileChatStream(body: string, threadId: string) {
   const errors: Error[] = [];
+  const events: StreamThreadRunEvent[] = [];
   const eventTypes: string[] = [];
   const terminalThreadIds: string[] = [];
   const dispatcher = createThreadRunSseDispatcher({
     onEvent(event) {
+      events.push(event);
       eventTypes.push(event.type);
       handleThreadRunStreamEvent(event, {
         fallbackThreadId: threadId,
@@ -626,5 +635,5 @@ function consumeAsMobileChatStream(body: string, threadId: string) {
   }
   dispatcher.flush();
 
-  return { errors, eventTypes, terminalThreadIds };
+  return { errors, events, eventTypes, terminalThreadIds };
 }

--- a/packages/codex-relay/test/mobile-stream-contract.test.ts
+++ b/packages/codex-relay/test/mobile-stream-contract.test.ts
@@ -86,7 +86,25 @@ describe("mobile stream contract", () => {
             {
               method: "item/agentMessage/delta",
               params: {
-                delta: "hi",
+                delta: "first",
+                itemId: "assistant-mobile-contract",
+                threadId: "app-thread-mobile-contract",
+                turnId: "turn-mobile-contract",
+              },
+            },
+            {
+              method: "item/agentMessage/delta",
+              params: {
+                delta: "\n",
+                itemId: "assistant-mobile-contract",
+                threadId: "app-thread-mobile-contract",
+                turnId: "turn-mobile-contract",
+              },
+            },
+            {
+              method: "item/agentMessage/delta",
+              params: {
+                delta: "second",
                 itemId: "assistant-mobile-contract",
                 threadId: "app-thread-mobile-contract",
                 turnId: "turn-mobile-contract",
@@ -95,7 +113,11 @@ describe("mobile stream contract", () => {
             {
               method: "item/completed",
               params: {
-                item: { id: "assistant-mobile-contract", text: "hi", type: "agentMessage" },
+                item: {
+                  id: "assistant-mobile-contract",
+                  text: "first\nsecond",
+                  type: "agentMessage",
+                },
                 threadId: "app-thread-mobile-contract",
                 turnId: "turn-mobile-contract",
               },
@@ -174,6 +196,11 @@ describe("mobile stream contract", () => {
     expect(consumed.events[assistantCreatedIndex]).toMatchObject({
       message: { state: "streaming" },
     });
+    expect(
+      consumed.events
+        .filter((event) => event.type === "thread.message.delta")
+        .map((event) => event.delta),
+    ).toEqual(["first", "\n", "second"]);
     expect(consumed.eventTypes).toContain("thread.message.delta");
     expect(consumed.terminalThreadIds).toContain("app-thread-mobile-contract");
 
@@ -181,7 +208,7 @@ describe("mobile stream contract", () => {
     expect(chatStore$.threadsById["app-thread-mobile-contract"].state.peek()).toBe("completed");
     expect(messages.map((message) => [message.role, message.content])).toEqual([
       ["user", "Reply with hi"],
-      ["assistant", "hi"],
+      ["assistant", "first\nsecond"],
     ]);
     expect(messages.find((message) => message.role === "assistant")?.state).toBe("completed");
   });

--- a/packages/react-native-direct-fetch/ios/HybridDirectFetch.swift
+++ b/packages/react-native-direct-fetch/ios/HybridDirectFetch.swift
@@ -667,13 +667,11 @@ class HybridDirectFetch: HybridDirectFetchSpec {
                 guard
                     let status,
                     status < 400,
-                    !data.isEmpty,
-                    let text = String(data: data, encoding: .utf8),
-                    !text.isEmpty
+                    !data.isEmpty
                 else {
                     return
                 }
-                onChunk(DirectFetchStreamChunk(bodyString: text))
+                Self.emitStreamChunk(data, onChunk: onChunk)
             }
 
             func finalize() {
@@ -1002,7 +1000,14 @@ class HybridDirectFetch: HybridDirectFetchSpec {
             return
         }
 
-        onChunk(DirectFetchStreamChunk(bodyString: text))
+        let chunk = DirectFetchStreamChunk(bodyString: text)
+        if Thread.isMainThread {
+            onChunk(chunk)
+        } else {
+            DispatchQueue.main.sync {
+                onChunk(chunk)
+            }
+        }
     }
 
     fileprivate static func headerValue(_ name: String, in headers: [[String: String]]) -> String? {


### PR DESCRIPTION
## Summary

- keep app-server assistant messages streamable from `item/started` and delta-first events
- deliver iOS LAN response chunks to React Native progressively on the main queue
- preserve whitespace-only app-server deltas such as standalone newlines
- preserve trailing Markdown whitespace and incomplete code-block newlines during rendering
- cover both new-run and running-thread attachment paths
- include patch changesets for `codex-relay` and `@codex-relay/mobile`

## Root causes

1. The app-server item mapper marked `item/started` assistant messages completed, so mobile ignored later deltas.
2. The iOS direct-fetch transport invoked Nitro callbacks from its background networking queue. Those callbacks were held until the request promise completed instead of reaching JavaScript progressively.
3. Codex emits line breaks as standalone `"\\n"` deltas. The relay used a general string helper that rejects whitespace-only values, so streaming text became `firstsecond`; the completed snapshot later replaced it with `first\\nsecond`.
4. The assistant renderer trimmed trailing Markdown whitespace and code-block newlines while content was incomplete.

## Regression coverage

- `item/started -> delta -> completed` remains streamable
- mobile stream contract now sends `"first"`, `"\\n"`, `"second"` and asserts all three deltas reach the real mobile SSE reducer
- streamed Markdown tests preserve soft breaks, blank lines, hard-break spaces, list indentation, and fenced-code newlines

## Manual QA

- reproduced the original iOS Release failure: 26 server deltas, no visible assistant text, then the whole response appeared at completion
- after the native fix, observed progressive partial text before completion
- after the relay fix, verified a newline-delimited 1–20 response renders as separate physical lines on iOS

## Validation

- `pnpm test`: 313 passed, 4 skipped
- `pnpm typecheck`
- `pnpm lint`
