### PR TITLE
feat: default to Astra in the App Store 1.5.0 OTA

### DIFF
--- a/.changeset/astra-default-ota.md
+++ b/.changeset/astra-default-ota.md
@@ -1,0 +1,6 @@
+---
+"codex-relay": patch
+"@codex-relay/mobile": patch
+---
+
+Default to GPT-6 Astra when available while preserving explicit model selections. This mobile OTA requires the Expo 57 App Store 1.5.0 binary and targets app version 1.5.0 through the existing release workflow.

--- a/apps/mobile/src/components/chat/ChatPreviewScreen.tsx
+++ b/apps/mobile/src/components/chat/ChatPreviewScreen.tsx
@@ -51,7 +51,7 @@ export function ChatPreviewScreen() {
   const [runtimeMode, setRuntimeMode] = useState<RuntimeMode>("default");
   const [collaborationMode, setCollaborationMode] = useState<ThreadCollaborationMode>("default");
   const composerFocusRequestKey = 0;
-  const [selectedModel, setSelectedModel] = useState("gpt-5.6-sol");
+  const [selectedModel, setSelectedModel] = useState("gpt-6-astra");
   const [selectedReasoningEffort, setSelectedReasoningEffort] = useState<
     ReasoningEffort | undefined
   >("medium");

--- a/apps/mobile/src/components/chat/chat-preview-models.ts
+++ b/apps/mobile/src/components/chat/chat-preview-models.ts
@@ -2,6 +2,14 @@ import type { CodexModel, ReasoningEffort } from "codex-relay/api-schema";
 
 export const previewModels: CodexModel[] = [
   previewModel({
+    defaultReasoningEffort: "medium",
+    description: "Most capable model for the hardest end-to-end work.",
+    displayName: "GPT-6 Astra",
+    efforts: ["low", "medium", "high", "xhigh", "max"],
+    id: "gpt-6-astra",
+    isDefault: true,
+  }),
+  previewModel({
     defaultReasoningEffort: "low",
     description: "Latest frontier agentic coding model.",
     displayName: "GPT-5.6-Sol",
@@ -28,7 +36,6 @@ export const previewModels: CodexModel[] = [
     displayName: "GPT-5.5",
     efforts: ["low", "medium", "high", "xhigh"],
     id: "gpt-5.5",
-    isDefault: true,
   }),
 ];
 

--- a/packages/codex-relay/src/app.ts
+++ b/packages/codex-relay/src/app.ts
@@ -181,7 +181,7 @@ import {
 import { resolveWorkspaceTerminalShell } from "./workspace-terminal-shell.js";
 
 const defaultWorkspacePath = process.cwd();
-const defaultCodexModel = "gpt-5.5";
+const defaultCodexModel = "gpt-6-astra";
 const execFileAsync = promisify(execFile);
 const IMAGE_ATTACHMENT_MAX_BYTES = 8 * 1024 * 1024;
 const WORKSPACE_FILE_PREVIEW_MAX_BYTES = 256 * 1024;
@@ -1407,11 +1407,18 @@ export function createApp(options: AppOptions = {}) {
   app.get(apiPaths.models, async (c) => {
     try {
       const models = appServer ? await appServer.listModels() : fallbackModels();
+      const hasAstra = models.some((model) => model.model === defaultCodexModel);
       return secureJson(
         c,
         options.pairing,
         secureSessionsByTokenHash,
-        ListModelsResponseSchema.parse({ models: models.map(mapAppServerModel) }),
+        ListModelsResponseSchema.parse({
+          models: models.map((model) =>
+            mapAppServerModel(
+              hasAstra ? { ...model, isDefault: model.model === defaultCodexModel } : model,
+            ),
+          ),
+        }),
       );
     } catch {
       return secureJson(
@@ -7939,7 +7946,7 @@ function fallbackModels(): AppServerModel[] {
     {
       id: defaultCodexModel,
       model: defaultCodexModel,
-      displayName: "GPT-5.5",
+      displayName: "GPT-6 Astra",
       description: "Default Codex model",
       isDefault: true,
       defaultReasoningEffort: "medium",
@@ -7948,6 +7955,7 @@ function fallbackModels(): AppServerModel[] {
         { reasoningEffort: "medium" },
         { reasoningEffort: "high" },
         { reasoningEffort: "xhigh" },
+        { reasoningEffort: "max" },
       ],
       additionalSpeedTiers: ["fast"],
       serviceTiers: [

--- a/packages/codex-relay/test/app.test.ts
+++ b/packages/codex-relay/test/app.test.ts
@@ -4129,7 +4129,7 @@ describe("Codex Relay server routes", () => {
           mode: "plan",
           settings: {
             developer_instructions: null,
-            model: "gpt-5.5",
+            model: "gpt-6-astra",
             reasoning_effort: null,
           },
         },
@@ -4203,7 +4203,7 @@ describe("Codex Relay server routes", () => {
           mode: "default",
           settings: {
             developer_instructions: null,
-            model: "gpt-5.5",
+            model: "gpt-6-astra",
             reasoning_effort: null,
           },
         },

--- a/packages/codex-relay/test/model-catalog.test.ts
+++ b/packages/codex-relay/test/model-catalog.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import { createApp } from "../src/app.js";
 import { CodexAppServerClient } from "../src/app-server.js";
 import type { CodexClient } from "../src/codex.js";
+import { normalizeRuntimePreferencesForModels } from "../../../apps/mobile/src/components/chat/model-picker-options.js";
 
 const unusedCodex: CodexClient = {
   resumeThread() {
@@ -14,9 +15,15 @@ const unusedCodex: CodexClient = {
 };
 
 describe("model catalog", () => {
-  it("returns GPT-5.6 models with their supported reasoning details", async () => {
+  it("returns GPT-6 Astra and GPT-5.6 models with their supported reasoning details", async () => {
     const appServer = new CodexAppServerClient();
     const models = [
+      model({
+        id: "gpt-6-astra",
+        displayName: "GPT-6 Astra",
+        defaultReasoningEffort: "medium",
+        efforts: ["low", "medium", "high", "xhigh", "max"],
+      }),
       model({
         id: "gpt-5.6-sol",
         displayName: "GPT-5.6-Sol",
@@ -47,9 +54,23 @@ describe("model catalog", () => {
     const body = await response.json();
 
     expect(response.status).toBe(200);
-    expect(body.models).toHaveLength(3);
+    expect(body.models).toHaveLength(4);
     expect(body.models[0]).toMatchObject({
+      model: "gpt-6-astra",
+      isDefault: true,
+      defaultReasoningEffort: "medium",
+      supportedReasoningEfforts: ["low", "medium", "high", "xhigh", "max"],
+      reasoningEffortOptions: [
+        { reasoningEffort: "low", description: "low description" },
+        { reasoningEffort: "medium", description: "medium description" },
+        { reasoningEffort: "high", description: "high description" },
+        { reasoningEffort: "xhigh", description: "xhigh description" },
+        { reasoningEffort: "max", description: "max description" },
+      ],
+    });
+    expect(body.models[1]).toMatchObject({
       model: "gpt-5.6-sol",
+      isDefault: false,
       defaultReasoningEffort: "low",
       supportedReasoningEfforts: ["low", "medium", "high", "xhigh", "max", "ultra"],
       reasoningEffortOptions: [
@@ -61,12 +82,61 @@ describe("model catalog", () => {
         { reasoningEffort: "ultra", description: "ultra description" },
       ],
     });
-    expect(body.models[2]).toMatchObject({
+    expect(body.models[3]).toMatchObject({
       model: "gpt-5.6-luna",
       supportedReasoningEfforts: ["low", "medium", "high", "xhigh", "max", "future"],
       reasoningEffortOptions: expect.arrayContaining([
         { reasoningEffort: "future", description: "future description" },
       ]),
+    });
+    expect(
+      normalizeRuntimePreferencesForModels(body.models, { runtimeMode: "default" }),
+    ).toMatchObject({
+      model: "gpt-6-astra",
+      reasoningEffort: "medium",
+    });
+    expect(
+      normalizeRuntimePreferencesForModels(body.models, {
+        runtimeMode: "default",
+        model: "gpt-5.6-sol",
+        reasoningEffort: "high",
+      }),
+    ).toMatchObject({ model: "gpt-5.6-sol", reasoningEffort: "high" });
+  });
+
+  it("keeps the host default when Astra is unavailable", async () => {
+    const appServer = new CodexAppServerClient();
+    vi.spyOn(appServer, "listModels").mockResolvedValue([
+      model({
+        id: "gpt-5.6-sol",
+        displayName: "GPT-5.6-Sol",
+        defaultReasoningEffort: "low",
+        efforts: ["low", "medium"],
+      }),
+    ]);
+    const app = createApp({
+      appServer,
+      codex: unusedCodex,
+      workspacePath: "/tmp/codex-relay-model-catalog",
+    });
+    const body = await (await app.request("/v1/models")).json();
+    expect(body.models).toHaveLength(1);
+    expect(body.models[0]).toMatchObject({ model: "gpt-5.6-sol", isDefault: true });
+  });
+
+  it("uses Astra when the host catalog cannot be loaded", async () => {
+    const appServer = new CodexAppServerClient();
+    vi.spyOn(appServer, "listModels").mockRejectedValue(new Error("offline"));
+    const app = createApp({
+      appServer,
+      codex: unusedCodex,
+      workspacePath: "/tmp/codex-relay-model-catalog",
+    });
+    const body = await (await app.request("/v1/models")).json();
+    expect(body.models[0]).toMatchObject({
+      model: "gpt-6-astra",
+      displayName: "GPT-6 Astra",
+      isDefault: true,
     });
   });
 });
@@ -85,6 +155,7 @@ function model({
   return {
     id,
     model: id,
+    isDefault: id === "gpt-5.6-sol",
     displayName,
     description: `${displayName} description`,
     defaultReasoningEffort,


### PR DESCRIPTION
Use GPT-6 Astra as the default when it is present in the host model catalog, including preview and collaboration-mode fallback. Preserve explicit user model selections and retain the host default when Astra is unavailable.

Depends on #91 (App Store 1.5.0 / Expo 57). This PR contains only application/server logic, tests, and an OTA release changeset; no native dependencies or native configuration changes. After #91 merges, retarget this PR to main.

The mobile changeset produces a 1.5.0-ship release using the existing workflow. OTA targets app version 1.5.0 exactly, excluding 1.4.x binaries and future binaries with potentially different native modules. Release the App Store 1.5.0 binary before the OTA release. No OTA has been deployed from this PR.

Validation: real Codex model/list now advertises gpt-6-astra; iOS preview launches with GPT-6 Astra Medium and opens its power selector; regression tests cover replacing an older host default, preserving explicit selections, absent Astra, catalog failure, and collaboration-mode fallback. Full tests, typecheck, and lint run on the final branch.
