### PR TITLE
fix: explain occupied relay ports without an unhandled crash

### DIFF
--- a/.changeset/tidy-relay-port.md
+++ b/.changeset/tidy-relay-port.md
@@ -1,0 +1,5 @@
+---
+"codex-relay": patch
+---
+
+Report an occupied server port with recovery instructions instead of an unhandled Node error.

--- a/packages/codex-relay/src/index.ts
+++ b/packages/codex-relay/src/index.ts
@@ -182,7 +182,22 @@ serve(
       }),
     );
   },
-);
+).on("error", (error: NodeJS.ErrnoException) => {
+  if (error.code !== "EADDRINUSE") {
+    throw error;
+  }
+
+  console.error(`Codex Relay could not start: ${hostname}:${port} is already in use.`);
+  console.error("Another Codex Relay instance or another application may be listening there.");
+  console.error("If it is your existing relay, print its pairing QR with:");
+  console.error(`  ${npxCommand} qr`);
+  console.error("To stop a background relay using this data directory:");
+  console.error(`  ${npxCommand} stop`);
+  console.error("Otherwise, identify the listener before stopping it:");
+  console.error(`  lsof -nP -iTCP:${port} -sTCP:LISTEN`);
+  console.error("To run a separate relay, use a free PORT and a separate CODEX_RELAY_HOME.");
+  stopRelayAppServer(1);
+});
 
 function stopRelayAppServer(exitCode: number) {
   relayAppServer?.close();

--- a/packages/codex-relay/test/startup-port.test.ts
+++ b/packages/codex-relay/test/startup-port.test.ts
@@ -1,0 +1,62 @@
+import { execFile } from "node:child_process";
+import { once } from "node:events";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { createServer } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect, test } from "vitest";
+
+test("an occupied port reports recovery instructions without overwriting running state", async () => {
+  const listener = createServer();
+  const home = await mkdtemp(join(tmpdir(), "relay-port-test-"));
+  try {
+    listener.listen(0, "127.0.0.1");
+    await once(listener, "listening");
+    const address = listener.address();
+    if (!address || typeof address === "string") throw new Error("Missing listener address");
+    const statePath = join(home, "server-state.json");
+    const pidPath = join(home, "server.pid");
+    await writeFile(statePath, "existing state\n");
+    await writeFile(pidPath, "existing pid\n");
+    const result = await new Promise<{
+      code: number | string | null | undefined;
+      stdout: string;
+      stderr: string;
+    }>((resolve) => {
+      execFile(
+        process.execPath,
+        ["--import", "tsx", "src/cli.ts"],
+        {
+          cwd: fileURLToPath(new URL("..", import.meta.url)),
+          env: {
+            ...process.env,
+            HOST: "127.0.0.1",
+            PORT: String(address.port),
+            CODEX_RELAY_HOME: home,
+            CODEX_RELAY_AUTH_DB_PATH: join(home, "auth.db"),
+            CODEX_RELAY_PID_PATH: pidPath,
+            CODEX_RELAY_APP_SERVER_MODE: "stdio",
+          },
+          timeout: 15_000,
+        },
+        (error, stdout, stderr) => resolve({ code: error?.code, stdout, stderr }),
+      );
+    });
+    expect(result.code).toBe(1);
+    expect(result.stderr).toContain(`127.0.0.1:${address.port} is already in use`);
+    expect(result.stderr).toContain("npx codex-relay@latest qr");
+    expect(result.stderr).toContain("npx codex-relay@latest stop");
+    expect(result.stderr).toContain(`-iTCP:${address.port}`);
+    expect(result.stderr).toContain("CODEX_RELAY_HOME");
+    expect(result.stderr).not.toContain("Unhandled 'error' event");
+    expect(result.stderr).not.toContain("node:events");
+    expect(result.stdout).not.toContain("Pairing:");
+    expect(await readFile(statePath, "utf8")).toBe("existing state\n");
+    expect(await readFile(pidPath, "utf8")).toBe("existing pid\n");
+    expect(listener.listening).toBe(true);
+  } finally {
+    if (listener.listening) await new Promise<void>((resolve) => listener.close(() => resolve()));
+    await rm(home, { recursive: true, force: true });
+  }
+}, 20_000);


### PR DESCRIPTION
Starting the relay while its configured port is occupied currently throws an unhandled `EADDRINUSE` error. Handle that server event with a clear address/port diagnostic and instructions for using an existing relay, stopping a background instance, identifying the listener, or configuring a separate relay.

The failed process exits with status 1 through the existing app-server cleanup path. It does not stop the listener, print a new pairing QR, or overwrite server state/PID files. Other server errors retain their existing behavior. Includes a patch changeset.

Closes #96.

Validation:

- Regression test launches the actual CLI against an occupied ephemeral port and checks exit status, diagnostics, preservation of state/PID files, and continued listener availability.
- `pnpm test`: 314 passed, 4 skipped.
- `pnpm typecheck`: passed across the workspace.
- `pnpm lint`: passed, including formatting.
- `pnpm --filter codex-relay build`: passed.

The existing relay on the development host was not restarted or modified.
