### PR TITLE
fix: load recent sessions without slow rollout rescans

### DIFF
--- a/.changeset/recent-session-list.md
+++ b/.changeset/recent-session-list.md
@@ -1,0 +1,5 @@
+---
+"codex-relay": patch
+---
+
+Read recent sessions from the Codex index and limit the list to 20 by default, avoiding mobile timeouts from repeatedly scanning large legacy histories. Add CODEX_RELAY_THREAD_LIST_LIMIT to control the visible history size without deleting history.

--- a/packages/codex-relay/README.md
+++ b/packages/codex-relay/README.md
@@ -28,6 +28,14 @@ npx codex-relay@latest approve XXXX-XXXX
 
 After approval, the phone can list Codex threads, start new work, stream messages, and handle approval prompts from the local Codex runtime.
 
+The thread list shows the 20 most recently active, non-archived root sessions across
+workspaces. This does not delete or archive older sessions. Set
+`CODEX_RELAY_THREAD_LIST_LIMIT=100` before starting the relay to show more history.
+The relay reads Codex's session index so refreshing the list does not repeatedly
+parse large legacy rollout files. An empty index triggers a bounded history lookup;
+legacy files copied into a partially populated index may need to be discovered by
+Codex before they appear in the relay.
+
 ## Shared Terminal and Mobile Sessions
 
 On macOS, Codex Relay prefers Codex's shared Unix socket so terminal and mobile clients can follow the same live sessions. If the shared app-server cannot start or initialize, the relay prints a warning and continues with a private app-server.

--- a/packages/codex-relay/src/app-server.ts
+++ b/packages/codex-relay/src/app-server.ts
@@ -319,31 +319,35 @@ export class CodexAppServerClient {
     return this.ensureInitialized();
   }
 
-  async listThreads(limit = 80) {
-    const threads: AppServerThread[] = [];
-    const seenCursors = new Set<string>();
-    let cursor: string | undefined;
-    do {
-      const response = await this.request<{
-        data: AppServerThread[];
-        nextCursor?: string | null;
-      }>("thread/list", {
-        archived: false,
-        limit,
-        sortDirection: "desc",
-        sortKey: "recency_at",
-        sourceKinds: ["cli", "vscode", "exec", "appServer"],
-        ...(cursor ? { cursor, useStateDbOnly: true } : {}),
-      });
-      threads.push(...response.data);
-      const nextCursor = response.nextCursor ?? undefined;
-      if (!nextCursor || seenCursors.has(nextCursor)) {
-        break;
-      }
-      seenCursors.add(nextCursor);
-      cursor = nextCursor;
-    } while (cursor);
-    return threads;
+  async listThreads(limit = Number(process.env.CODEX_RELAY_THREAD_LIST_LIMIT ?? 20)) {
+    if (!Number.isSafeInteger(limit) || limit < 1) {
+      throw new Error("CODEX_RELAY_THREAD_LIST_LIMIT must be a positive integer.");
+    }
+    const startedAt = Date.now();
+    const params = {
+      archived: false,
+      limit,
+      sortDirection: "desc",
+      sortKey: "recency_at",
+      sourceKinds: ["cli", "vscode", "exec", "appServer"],
+    };
+    // Rescanning legacy rollouts on every refresh can exceed the mobile timeout.
+    // Modern Codex sessions are indexed as they are written.
+    let response = await this.request<{ data: AppServerThread[] }>("thread/list", {
+      ...params,
+      useStateDbOnly: true,
+    });
+    if (response.data.length === 0) {
+      // Let Codex discover older history when there is no indexed history yet.
+      response = await this.request<{ data: AppServerThread[] }>("thread/list", params);
+    }
+    relayDebugLog("thread.list.completed", {
+      durationMs: Date.now() - startedAt,
+      limit,
+      count: response.data.length,
+    });
+    // A limit is a total bound, not a page size followed by an unbounded scan.
+    return response.data.slice(0, limit);
   }
 
   async readThread(threadId: string, options: { includeTurns?: boolean } = {}) {

--- a/packages/codex-relay/test/app-server.test.ts
+++ b/packages/codex-relay/test/app-server.test.ts
@@ -196,7 +196,7 @@ describe("CodexAppServerClient shared socket mode", () => {
     }
   });
 
-  it("lists every root thread page without rescanning rollout files after the first page", async () => {
+  it("bounds the recent thread list and never follows older history cursors", async () => {
     const codexHome = await mkdtemp(join(socketTempRoot, "codex-relay-app-server-pages-"));
     const socketPath = join(codexHome, "app-server-control", "app-server-control.sock");
     const server = await startSharedSocketServer(socketPath, (request) => {
@@ -219,25 +219,65 @@ describe("CodexAppServerClient shared socket mode", () => {
       const threads = await client.listThreads(1);
       const requests = server.requests.filter((request) => request.method === "thread/list");
 
-      expect(threads.map((thread) => thread.id)).toEqual(["thread-newer", "thread-older"]);
-      expect(requests).toHaveLength(2);
+      expect(threads.map((thread) => thread.id)).toEqual(["thread-newer"]);
+      expect(requests).toHaveLength(1);
       expect(requests[0]?.params).toMatchObject({
         limit: 1,
         sortKey: "recency_at",
         sortDirection: "desc",
         sourceKinds: ["cli", "vscode", "exec", "appServer"],
       });
-      expect(requests[0]?.params).not.toHaveProperty("useStateDbOnly");
-      expect(requests[1]?.params).toMatchObject({
-        cursor: "page-2",
-        useStateDbOnly: true,
-      });
+      expect(requests[0]?.params).toHaveProperty("useStateDbOnly", true);
+      expect(requests[0]?.params).not.toHaveProperty("cursor");
     } finally {
       client.close();
       await server.close();
       await rm(codexHome, { force: true, recursive: true });
     }
   });
+
+  it("discovers history for an empty index and defaults to twenty recent threads", async () => {
+    const codexHome = await mkdtemp(join(socketTempRoot, "codex-relay-empty-index-"));
+    const socketPath = join(codexHome, "app-server-control", "app-server-control.sock");
+    const server = await startSharedSocketServer(socketPath, (request) => {
+      if (request.method !== "thread/list") return {};
+      return request.params?.useStateDbOnly
+        ? { data: [], nextCursor: null }
+        : { data: [{ id: "legacy-thread" }], nextCursor: "older" };
+    });
+    vi.stubEnv("CODEX_HOME", codexHome);
+    vi.stubEnv("CODEX_RELAY_APP_SERVER_MODE", "socket");
+    vi.stubEnv("CODEX_RELAY_THREAD_LIST_LIMIT", "20");
+    const client = new CodexAppServerClient();
+    try {
+      await expect(client.listThreads()).resolves.toEqual([{ id: "legacy-thread" }]);
+      const requests = server.requests.filter((request) => request.method === "thread/list");
+      expect(requests).toHaveLength(2);
+      expect(requests[0]?.params).toMatchObject({ limit: 20, useStateDbOnly: true });
+      expect(requests[1]?.params).toMatchObject({ limit: 20 });
+      expect(requests[1]?.params).not.toHaveProperty("useStateDbOnly");
+      expect(requests[1]?.params).not.toHaveProperty("cursor");
+      vi.stubEnv("CODEX_RELAY_THREAD_LIST_LIMIT", "10");
+      await client.listThreads();
+      expect(
+        server.requests.filter((request) => request.method === "thread/list").at(-1)?.params,
+      ).toHaveProperty("limit", 10);
+    } finally {
+      client.close();
+      await server.close();
+      await rm(codexHome, { force: true, recursive: true });
+    }
+  });
+
+  it.each(["0", "-1", "1.5", "NaN"])(
+    "rejects invalid thread limits before connecting: %s",
+    async (limit) => {
+      vi.stubEnv("CODEX_RELAY_THREAD_LIST_LIMIT", limit);
+      const client = new CodexAppServerClient();
+      await expect(client.listThreads()).rejects.toThrow("positive integer");
+      client.close();
+    },
+  );
 
   it.skipIf(process.platform === "win32")(
     "replaces a stale Unix socket after a slow shared app-server startup",


### PR DESCRIPTION
## Summary

A relay with large legacy histories took about 20 seconds to return its thread list, exceeding the iPhone's 15-second deadline and causing repeated reconnect messages. Read Codex's session index and return at most the 20 most recently active root sessions across workspaces, instead of rescanning an 80-item first page and following every cursor.

`CODEX_RELAY_THREAD_LIST_LIMIT` controls the visible history size. No sessions are deleted or archived; an empty index falls back to bounded history discovery. Includes regression tests, documentation, and a patch changeset.

Closes #99.

## Validation

- [x] Relevant tests, typecheck, lint, and manual checks completed.
- [x] Validation limitations documented.
- `pnpm test`: 319 passed, 4 skipped.
- `pnpm typecheck`, `pnpm lint` (including formatting), and relay build passed on this independent branch.
- Local replay reduced the initialized route from approximately 19.9 seconds to 55 ms with 20 results. The reporter confirmed immediate session loading on the existing iPhone app.

## Notes

This PR is independent of the pairing-flow work for #100 and requires no mobile app update. The limit applies across workspaces. Legacy rollout files copied into a partially populated index may need to be discovered by Codex before they appear; this limitation is documented in the README. Measurements are from one host and are not a latency guarantee for every history.
