### PR TITLE
fix: make pairing responsive and approve in the relay terminal

### DIFF
--- a/.changeset/interactive-pairing.md
+++ b/.changeset/interactive-pairing.md
@@ -1,0 +1,8 @@
+---
+"codex-relay": patch
+"@codex-relay/mobile": patch
+---
+
+Approve pairing directly in the interactive relay terminal by confirming the code and typing y followed by Enter. Keep the approval command for background relays, and explain both options on the phone.
+
+Make the pairing route own deep links, show connection progress immediately, probe candidate addresses concurrently, and preserve timeout details in network errors.

--- a/apps/mobile/src/components/chat/ChatScreen.tsx
+++ b/apps/mobile/src/components/chat/ChatScreen.tsx
@@ -33,6 +33,7 @@ import * as ImagePicker from "expo-image-picker";
 import { useFocusEffect, useNavigation } from "expo-router";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
+  ActivityIndicator,
   Alert,
   AppState,
   Keyboard,
@@ -184,14 +185,14 @@ const MIN_CHAT_PANE_WIDTH = 420;
 const MIN_PREVIEW_PANE_WIDTH = 360;
 const EMPTY_SKILLS: AgentSkill[] = [];
 const EMPTY_THREADS: ThreadSummary[] = [];
-let isHandlingPairingLink = false;
-let lastHandledPairingUrl: string | undefined;
 
 type ChatScreenProps = {
   initialPairingUrl?: string | null;
 };
 
 export function ChatScreen({ initialPairingUrl }: ChatScreenProps = {}) {
+  const isHandlingPairingLink = useRef(false);
+  const lastHandledPairingUrl = useRef<string | undefined>(undefined);
   const { width } = useWindowDimensions();
   const { isSidebarVisible, toggleSidebar } = useIpadSplitLayout();
   const [pasteApprovalCode, setPasteApprovalCode] = useState<string | undefined>(undefined);
@@ -1276,14 +1277,15 @@ export function ChatScreen({ initialPairingUrl }: ChatScreenProps = {}) {
       const pairingUrl = url?.trim();
       if (
         !pairingUrl?.startsWith("codex-relay://pair") ||
-        pairingUrl === lastHandledPairingUrl ||
-        isHandlingPairingLink
+        (pairingUrl === lastHandledPairingUrl.current && hasCodexRelaySession()) ||
+        isHandlingPairingLink.current
       ) {
         return;
       }
 
-      isHandlingPairingLink = true;
+      isHandlingPairingLink.current = true;
       setPastePairing(true);
+      setPastePairOpen(true);
       setPasteApprovalCode(undefined);
       setPasteApprovalServerUrl(undefined);
       try {
@@ -1298,15 +1300,19 @@ export function ChatScreen({ initialPairingUrl }: ChatScreenProps = {}) {
         clearServerState(queryClient);
         syncPairedSessionState();
         setPastePairOpen(false);
-        lastHandledPairingUrl = pairingUrl;
+        lastHandledPairingUrl.current = pairingUrl;
         setPasteApprovalCode(undefined);
         setPasteApprovalServerUrl(undefined);
         hapticSuccess();
         await refresh();
-      } catch {
-        Alert.alert("Pairing failed", pairingFailureAlertMessage);
+      } catch (caught) {
+        setPastePairOpen(false);
+        Alert.alert(
+          "Pairing failed",
+          caught instanceof Error ? caught.message : pairingFailureAlertMessage,
+        );
       } finally {
-        isHandlingPairingLink = false;
+        isHandlingPairingLink.current = false;
         setPastePairing(false);
       }
     },
@@ -1314,21 +1320,11 @@ export function ChatScreen({ initialPairingUrl }: ChatScreenProps = {}) {
   );
 
   useEffect(() => {
-    let isMounted = true;
+    // Expo Router delivers deep links to /pair. The background chat screen must
+    // not race that route for an approval code that only its hidden UI can show.
     if (initialPairingUrl) {
       void handlePairingLink(initialPairingUrl);
     }
-    void Linking.getInitialURL().then((url) => {
-      if (isMounted) {
-        void handlePairingLink(url);
-      }
-    });
-    const unsubscribe = subscribeToPairingLinks(handlePairingLink);
-
-    return () => {
-      isMounted = false;
-      unsubscribe();
-    };
   }, [handlePairingLink, initialPairingUrl]);
 
   const closeScannerSurface = useCallback(async () => {
@@ -2441,10 +2437,13 @@ export function ChatScreen({ initialPairingUrl }: ChatScreenProps = {}) {
               </Pressable>
             </View>
             <View style={styles.manualFields}>
+              {isPairing && !pasteApprovalCode ? (
+                <ActivityIndicator accessibilityLabel="Connecting to your computer" />
+              ) : null}
               <ThemedText type="small" themeColor="textSecondary">
                 {pasteApprovalCode
-                  ? "Finish pairing from the Terminal window where codex-relay is running."
-                  : "QR recognized. Connecting to the relay..."}
+                  ? "If the relay is running interactively, switch to that terminal, check that this code matches, then type y and press Enter at the approval prompt."
+                  : "Finding your computer on LAN or Tailscale..."}
               </ThemedText>
               {pasteApprovalCode ? (
                 <View style={styles.manualApproval}>
@@ -2453,7 +2452,7 @@ export function ChatScreen({ initialPairingUrl }: ChatScreenProps = {}) {
                     {pasteApprovalCode}
                   </ThemedText>
                   <ThemedText type="small" themeColor="textSecondary">
-                    Run this on your computer:
+                    Alternatively, copy this command and run it in a new terminal on your computer:
                   </ThemedText>
                   <CopyableCommand
                     command={approvalCommand(pasteApprovalCode, pasteApprovalServerUrl)}
@@ -2740,13 +2739,6 @@ function agentSkillsFromPromptSkills(skills: ApiPromptSkill[], availableSkills: 
   });
 }
 
-function subscribeToPairingLinks(onUrl: (url: string) => void) {
-  const urlListener = Linking.addEventListener("url", (event) => {
-    onUrl(event.url);
-  });
-  return () => urlListener.remove();
-}
-
 function mergeAgentSkills(currentSkills: AgentSkill[], nextSkills: AgentSkill[]) {
   const seen = new Set(currentSkills.map(agentSkillKey));
   const merged = [...currentSkills];
@@ -2847,7 +2839,7 @@ function delay(ms: number) {
 }
 
 function approvalMessage(approvalCode: string, serverUrl?: string) {
-  return `Run ${approvalCommand(approvalCode, serverUrl)} in the server terminal.`;
+  return `Check code ${approvalCode} in the running relay terminal and type y then Enter when prompted. Alternatively, run ${approvalCommand(approvalCode, serverUrl)} in a new terminal on your computer.`;
 }
 
 function readScannedPayload(result: unknown) {

--- a/apps/mobile/src/components/chat/ConnectionBanner.tsx
+++ b/apps/mobile/src/components/chat/ConnectionBanner.tsx
@@ -130,7 +130,7 @@ export function ConnectionBanner({
               icon="check"
               label="3"
               title="Scan and approve"
-              body="Scan the QR shown in Terminal. When a code appears, approve it on your computer."
+              body="Scan the QR shown in Terminal. Approve in the running relay terminal when prompted, or use the command shown on your phone in a new terminal."
             />
           </View>
           <View style={styles.pairActions}>

--- a/apps/mobile/src/lib/api-error-message.test.ts
+++ b/apps/mobile/src/lib/api-error-message.test.ts
@@ -1,0 +1,11 @@
+import { expect, it } from "vitest";
+
+import { errorMessage } from "./api-error-message";
+
+it("preserves timeout and native error messages instead of reporting network error", () => {
+  expect(errorMessage(new Error("Request timed out."), "network error")).toBe("Request timed out.");
+  expect(errorMessage({ error: { message: "Pair this device" } }, "fallback")).toBe(
+    "Pair this device",
+  );
+  expect(errorMessage(undefined, "network error")).toBe("network error");
+});

--- a/apps/mobile/src/lib/api-error-message.ts
+++ b/apps/mobile/src/lib/api-error-message.ts
@@ -1,0 +1,13 @@
+export function errorMessage(payload: unknown, fallback: string) {
+  if (payload instanceof Error && payload.message) {
+    return payload.message;
+  }
+  return payload &&
+    typeof payload === "object" &&
+    "error" in payload &&
+    payload.error &&
+    typeof payload.error === "object" &&
+    "message" in payload.error
+    ? String(payload.error.message)
+    : fallback;
+}

--- a/apps/mobile/src/lib/codex-relay-api.ts
+++ b/apps/mobile/src/lib/codex-relay-api.ts
@@ -1,5 +1,8 @@
 import "react-native-get-random-values";
 
+import { errorMessage } from "./api-error-message";
+import { firstReachablePairingUrl } from "./pairing-reachability";
+
 import {
   ArchiveThreadResponseSchema,
   CheckoutWorkspaceBranchRequestSchema,
@@ -225,7 +228,26 @@ export async function pairWithQrPayload(
   const pairingPayload = parsePairingQrPayload(payload);
   const connectionErrors: PairingCandidateConnectionError[] = [];
 
-  for (const serverUrl of pairingPayload.serverUrls) {
+  const reachableUrl = await firstReachablePairingUrl(
+    pairingPayload.serverUrls,
+    async (serverUrl) => {
+      const response = await fetchWithNetworkContext(`${serverUrl}${apiPaths.version}`, {
+        timeoutMs: pairingConnectTimeoutMs,
+      });
+      if (!response.ok || !VersionResponseSchema.safeParse(await response.json()).success) {
+        throw new Error(`No Codex Relay found at ${serverUrl}.`);
+      }
+    },
+  ).catch(() => {
+    throw new Error(
+      "Could not reach your computer. Check that the relay is running and both devices are on the same LAN or connected to Tailscale.",
+    );
+  });
+  const serverUrls = [
+    reachableUrl,
+    ...pairingPayload.serverUrls.filter((url) => url !== reachableUrl),
+  ];
+  for (const serverUrl of serverUrls) {
     try {
       const paired = await pairWithApproval(serverUrl, pairingPayload.serverPublicKey, handlers);
       saveCodexRelayServerUrlCandidates([paired.serverUrl, ...pairingPayload.serverUrls]);
@@ -1322,17 +1344,6 @@ function authorizationHeader() {
 
 function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-function errorMessage(payload: unknown, fallback: string) {
-  return payload &&
-    typeof payload === "object" &&
-    "error" in payload &&
-    payload.error &&
-    typeof payload.error === "object" &&
-    "message" in payload.error
-    ? String(payload.error.message)
-    : fallback;
 }
 
 function errorCode(payload: unknown) {

--- a/apps/mobile/src/lib/pairing-reachability.test.ts
+++ b/apps/mobile/src/lib/pairing-reachability.test.ts
@@ -1,0 +1,24 @@
+import { expect, it, vi } from "vitest";
+
+import { firstReachablePairingUrl } from "./pairing-reachability";
+
+it("uses reachable LAN immediately while the first VPN address is still pending", async () => {
+  const probe = vi.fn<(url: string) => Promise<void>>((url) =>
+    url === "vpn" ? new Promise<void>(() => {}) : Promise.resolve(),
+  );
+  await expect(firstReachablePairingUrl(["vpn", "lan"], probe)).resolves.toBe("lan");
+  expect(probe.mock.calls).toEqual([["vpn"], ["lan"]]);
+});
+
+it("keeps looking after a failed address and reports all failures when none work", async () => {
+  await expect(
+    firstReachablePairingUrl(["bad", "lan"], async (url) => {
+      if (url === "bad") throw new Error("unreachable");
+    }),
+  ).resolves.toBe("lan");
+  await expect(
+    firstReachablePairingUrl(["bad"], async () => {
+      throw new Error("unreachable");
+    }),
+  ).rejects.toBeInstanceOf(AggregateError);
+});

--- a/apps/mobile/src/lib/pairing-reachability.ts
+++ b/apps/mobile/src/lib/pairing-reachability.ts
@@ -1,0 +1,13 @@
+// Probe without creating pairing attempts: only the winning address gets an
+// approval request. A dead VPN address must not delay a reachable LAN address.
+export async function firstReachablePairingUrl(
+  urls: string[],
+  probe: (url: string) => Promise<void>,
+) {
+  return Promise.any(
+    urls.map(async (url) => {
+      await probe(url);
+      return url;
+    }),
+  );
+}

--- a/packages/codex-relay/README.md
+++ b/packages/codex-relay/README.md
@@ -20,7 +20,12 @@ npx codex-relay@latest
 
 The CLI prints a QR code, a mobile URL, and a `codex-relay://pair...` pairing payload. Scan the QR code from the mobile app. If the relay detects multiple possible network addresses, the QR includes them and the app automatically uses the first address it can reach. If scanning is not available, paste the full pairing payload into the app.
 
-When the app shows an approval code, approve it on the computer:
+When the app shows an approval code, the interactive relay terminal shows the
+same code and asks `Approve? [y/N]`. Check that the codes match, then type `y`
+and press Enter in that terminal. Other input leaves the request unapproved.
+No second terminal is needed.
+
+For background relays or non-interactive output, use the approval command:
 
 ```sh
 npx codex-relay@latest approve XXXX-XXXX

--- a/packages/codex-relay/src/index.ts
+++ b/packages/codex-relay/src/index.ts
@@ -20,6 +20,7 @@ import {
   type ConnectUrlCandidate,
 } from "./pairing-url-candidates.js";
 import { createTursoPairingSessionStore } from "./pairing-store.js";
+import { createTerminalPairingApprover } from "./terminal-pairing.js";
 import { codexRelayDataPath, legacyCodexRelayDataPath } from "./paths.js";
 import { createFileRuntimePreferencesStore } from "./preferences-store.js";
 import {
@@ -29,6 +30,7 @@ import {
 } from "./secure-transport.js";
 
 const port = Number(process.env.PORT ?? 8787);
+let activePort = port;
 const hostname = process.env.HOST ?? "0.0.0.0";
 const dangerouslyAutoApprove = process.env.CODEX_RELAY_DANGEROUSLY_AUTO_APPROVE === "1";
 const serverIdentity = await getServerIdentity();
@@ -56,6 +58,13 @@ const sessionStore = await createTursoPairingSessionStore(
   process.env.CODEX_RELAY_AUTH_DB_PATH ??
     (await prepareCodexRelayDataPath("auth.db", ["auth.db-shm", "auth.db-wal"])),
 );
+const terminalPairing = createTerminalPairingApprover({
+  input: process.stdin,
+  output: process.stdout,
+  sessions: sessionStore,
+  onApproved: () =>
+    logRuntimeEvent("Approved", "Pairing approved. Waiting for your phone to finish connecting."),
+});
 const preferencesStore = createFileRuntimePreferencesStore(
   process.env.CODEX_RELAY_PREFERENCES_PATH ?? (await prepareCodexRelayDataPath("preferences.json")),
 );
@@ -103,12 +112,13 @@ serve(
             `Handshake received${remoteAddress ? ` from ${remoteAddress}` : ""}.`,
           );
         },
-        onPairApprovalRequested: ({ clientName }) => {
+        onPairApprovalRequested: ({ approvalCode, clientName }) => {
           const name = clientName ? ` from ${clientName}` : "";
           logRuntimeEvent(
             "Approval",
-            `Pairing approval requested${name}. Use the code shown in the mobile app to approve locally.`,
+            `Pairing approval requested${name}. Command: ${formatApprovalCommand(approvalCode, activePort)}`,
           );
+          void terminalPairing.request(approvalCode);
         },
         onPairApproved: ({ clientName }) => {
           const name = clientName ? ` for ${clientName}` : "";
@@ -137,6 +147,7 @@ serve(
     port,
   },
   (info) => {
+    activePort = info.port;
     const listenUrl = `http://${info.address}:${info.port}`;
     const connectUrlCandidates = getConnectUrlCandidates({ listenUrl, port: info.port });
     const connectUrl = connectUrlCandidates[0]?.url ?? listenUrl;
@@ -242,9 +253,11 @@ function formatStartupInstructions(details: {
       : `${color.prompt("›")} Waiting for pairing requests`,
     details.dangerouslyAutoApprove
       ? `${color.prompt("›")} Disable this for normal use.`
-      : `${color.prompt("›")} Approve a device with ${color.command(
-          formatApprovalCommand("<code>", details.port),
-        )}`,
+      : process.stdin.isTTY && process.stdout.isTTY
+        ? `${color.prompt("›")} Approve a device here when prompted: type y and press Enter.`
+        : `${color.prompt("›")} Approve a device with ${color.command(
+            formatApprovalCommand("<code>", details.port),
+          )}`,
   ];
   return ["", ...lines, ""].join("\n");
 }

--- a/packages/codex-relay/src/terminal-pairing.ts
+++ b/packages/codex-relay/src/terminal-pairing.ts
@@ -1,0 +1,117 @@
+import { createInterface, type Interface } from "node:readline";
+import type { Readable, Writable } from "node:stream";
+
+import type { PairingSessionStore, PendingPairing } from "./pairing-store.js";
+
+type Options = {
+  input: Readable & { isTTY?: boolean };
+  output: Writable & { isTTY?: boolean };
+  sessions: Pick<PairingSessionStore, "getPendingPairing" | "approvePendingPairing">;
+  onApproved: (pairing: PendingPairing) => void;
+};
+
+export function createTerminalPairingApprover(options: Options) {
+  const queue: PendingPairing[] = [];
+  let active: PendingPairing | undefined;
+  let reader: Interface | undefined;
+  let expiry: ReturnType<typeof setTimeout> | undefined;
+  let answering = false;
+  let closed = false;
+
+  function print(message: string) {
+    options.output.write(`${message}\n`);
+  }
+
+  function close() {
+    closed = true;
+    queue.length = 0;
+    active = undefined;
+    clearTimeout(expiry);
+    reader?.close();
+  }
+
+  function next() {
+    if (closed || active || answering) return;
+    clearTimeout(expiry);
+    active = queue.shift();
+    while (active && active.expiresAt <= Date.now()) {
+      active = queue.shift();
+    }
+    if (!active) return;
+    const clientName = (active.clientName ?? "mobile device")
+      .replace(/[\p{Cc}\p{Cf}]/gu, "")
+      .slice(0, 80);
+    print(`\nPairing request from ${clientName}. Code: ${active.approvalCode}`);
+    print("Check that this code matches your phone. Approve? [y/N] (then Enter)");
+    expiry = setTimeout(
+      () => {
+        print("Pairing request expired. Open the pairing link again to retry.");
+        active = undefined;
+        next();
+      },
+      Math.max(1, active.expiresAt - Date.now()),
+    );
+  }
+
+  async function answer(line: string) {
+    if (!active || answering || closed) return;
+    const pairing = active;
+    active = undefined;
+    answering = true;
+    clearTimeout(expiry);
+    try {
+      if (!/^(y|yes)$/i.test(line.trim())) {
+        print("Not approved. You can still use the approve command for this request.");
+        return;
+      }
+      // The store rechecks expiry at the moment of approval, not just at display.
+      const approved = await options.sessions.approvePendingPairing(
+        pairing.approvalCode,
+        Date.now(),
+      );
+      if (approved) {
+        options.onApproved(approved);
+      } else {
+        print(
+          "This pairing request expired or was already completed. Open the pairing link again.",
+        );
+      }
+    } catch {
+      print("Could not approve pairing. Try the approve command or open the pairing link again.");
+    } finally {
+      answering = false;
+      next();
+    }
+  }
+
+  return {
+    close,
+    async request(approvalCode: string) {
+      // Never interpret redirected/piped input as consent.
+      if (closed || !options.input.isTTY || !options.output.isTTY) return;
+      try {
+        const pairing = await options.sessions.getPendingPairing(approvalCode, Date.now());
+        if (!pairing || pairing.approved || closed) return;
+        if (
+          active?.approvalCode === approvalCode ||
+          queue.some((item) => item.approvalCode === approvalCode)
+        )
+          return;
+        if (queue.length >= 10) {
+          print("More pairing requests are waiting. Use the approve command for this request.");
+          return;
+        }
+        if (!reader) {
+          // Keep the terminal's normal line input and Ctrl-C behavior.
+          reader = createInterface({ input: options.input, terminal: false });
+          reader.on("line", (line) => void answer(line));
+          reader.on("close", close);
+        }
+        queue.push(pairing);
+        next();
+      } catch {
+        print("Could not show pairing approval. Use the approve command instead.");
+      }
+    },
+  };
+}

--- a/packages/codex-relay/test/terminal-pairing.test.ts
+++ b/packages/codex-relay/test/terminal-pairing.test.ts
@@ -1,0 +1,124 @@
+import { PassThrough, Writable } from "node:stream";
+import { afterEach, expect, it, vi } from "vitest";
+
+import type { PendingPairing } from "../src/pairing-store.js";
+import { createTerminalPairingApprover } from "../src/terminal-pairing.js";
+
+const cleanup: Array<() => void> = [];
+afterEach(() => {
+  cleanup.splice(0).forEach((close) => close());
+  vi.useRealTimers();
+});
+
+function harness(interactive = true) {
+  let text = "";
+  const input = Object.assign(new PassThrough(), { isTTY: interactive });
+  const output = Object.assign(
+    new Writable({
+      write(chunk, _encoding, callback) {
+        text += chunk.toString();
+        callback();
+      },
+    }),
+    { isTTY: interactive },
+  );
+  const pairings = new Map<string, PendingPairing>();
+  const sessions = {
+    getPendingPairing: vi.fn<(code: string, now: number) => Promise<PendingPairing | undefined>>(
+      async (code, now) => {
+        const pairing = pairings.get(code);
+        return pairing && pairing.expiresAt > now ? pairing : undefined;
+      },
+    ),
+    approvePendingPairing: vi.fn<
+      (code: string, now: number) => Promise<PendingPairing | undefined>
+    >(async (code, now) => {
+      const pairing = pairings.get(code);
+      if (!pairing || pairing.expiresAt <= now) return undefined;
+      pairing.approved = true;
+      return pairing;
+    }),
+  };
+  const onApproved = vi.fn<(pairing: PendingPairing) => void>();
+  const approver = createTerminalPairingApprover({ input, output, sessions, onApproved });
+  cleanup.push(() => {
+    approver.close();
+    input.destroy();
+    output.destroy();
+  });
+  function add(code: string, lifetime = 60_000) {
+    pairings.set(code, {
+      approvalCode: code,
+      approved: false,
+      clientName: "My iPhone",
+      clientEphemeralPublicKey: "public-key",
+      clientNonce: "nonce",
+      serverUrl: "http://localhost:8787",
+      expiresAt: Date.now() + lifetime,
+    });
+    return approver.request(code);
+  }
+  return { add, approver, input, sessions, onApproved, pairings, text: () => text };
+}
+
+it("shows the code in the running terminal and approves only after explicit yes", async () => {
+  const h = harness();
+  await h.add("1234-ABCD");
+  expect(h.text()).toContain("My iPhone. Code: 1234-ABCD");
+  expect(h.text()).toContain("Approve? [y/N]");
+  expect(h.sessions.approvePendingPairing).not.toHaveBeenCalled();
+  h.input.write("y\n");
+  await vi.waitFor(() => expect(h.onApproved).toHaveBeenCalledOnce());
+  expect(h.sessions.approvePendingPairing).toHaveBeenCalledWith("1234-ABCD", expect.any(Number));
+});
+
+it.each(["\n", "n\n", "no\n", "npx codex-relay approve 1234-ABCD\n"])(
+  "does not approve on other input: %j",
+  async (answer) => {
+    const h = harness();
+    await h.add("1234-ABCD");
+    h.input.write(answer);
+    expect(h.text()).toContain("Not approved");
+    expect(h.sessions.approvePendingPairing).not.toHaveBeenCalled();
+  },
+);
+
+it("never reads piped input as consent", async () => {
+  const h = harness(false);
+  await h.add("1234-ABCD");
+  h.input.write("yes\n");
+  expect(h.sessions.getPendingPairing).not.toHaveBeenCalled();
+  expect(h.sessions.approvePendingPairing).not.toHaveBeenCalled();
+  expect(h.text()).toBe("");
+});
+
+it("queues requests without cancelling the active request's expiry", async () => {
+  vi.useFakeTimers();
+  const h = harness();
+  await h.add("1111-AAAA", 1000);
+  await h.add("2222-BBBB", 10_000);
+  expect(h.text()).not.toContain("2222-BBBB");
+  await vi.advanceTimersByTimeAsync(1001);
+  expect(h.text()).toContain("Pairing request expired");
+  expect(h.text()).toContain("2222-BBBB");
+  expect(h.sessions.approvePendingPairing).not.toHaveBeenCalled();
+});
+
+it("does not apply buffered answers to requests that have not been displayed yet", async () => {
+  const h = harness();
+  await h.add("1111-AAAA");
+  await h.add("2222-BBBB");
+  h.input.write("y\ny\n");
+  await vi.waitFor(() => expect(h.onApproved).toHaveBeenCalledOnce());
+  expect(h.sessions.approvePendingPairing).toHaveBeenCalledTimes(1);
+  expect(h.text()).toContain("2222-BBBB");
+});
+
+it("does not claim approval after a request was consumed or expired elsewhere", async () => {
+  const h = harness();
+  await h.add("1234-ABCD");
+  h.pairings.delete("1234-ABCD");
+  h.input.write("y\n");
+  await vi.waitFor(() => expect(h.text()).toContain("expired or was already completed"));
+  expect(h.onApproved).not.toHaveBeenCalled();
+});


### PR DESCRIPTION
## Summary

A pairing link can open the app and leave it looking idle even though the relay has generated an approval code. Let Expo Router's `/pair` screen own deep links, remove the competing background ChatScreen listeners/global guard, and show progress immediately. Probe candidate relay addresses concurrently so an unavailable VPN does not delay a reachable LAN address, and preserve timeout details in network errors.

Interactive relays now show the requesting device name and code and ask `Approve? [y/N]`; the user can type `y` and Enter in the same terminal. Approval remains explicit, piped input is never treated as consent, queued prompts expire, and the store rechecks validity when approval is submitted. Keep the existing command for background use. The iPhone explains in-terminal approval first and the copyable command/new-terminal alternative. Includes tests, README guidance, and relay/mobile patch changesets.

Closes #100.

## Validation

- [x] Relevant tests, typecheck, lint, and manual checks completed.
- [x] Validation limitations documented.
- `pnpm test`: 323 passed, 4 skipped on this independent branch.
- Mobile Vitest suite: 22 passed.
- Workspace typecheck, lint/formatting, relay build, and iOS Expo export passed.
- Isolated real-PTY test of the built CLI: pending pairing stays unapproved until `y`/Enter; approval completes the secure handshake with HTTP 201; Ctrl-C still exits normally.
- The reporter successfully paired the actual iPhone using the new terminal prompt in a local build containing this change.

## Notes

Independent of the session-list fix in #99. The existing phone app can use terminal approval immediately once the relay is updated. The progress, routing, address-selection, and copy changes require a mobile update.

The new mobile UI has not been run on an iPhone/simulator here, so no new screenshot is attached. The competing-handler mechanism is supported by source inspection and the observed pending-but-invisible approval, but the fix still needs device verification. Please check cold and warm Termius/browser deep links with Tailscale off, approval visibility, sign-out/re-pair, and unreachable-host failure feedback. Export success is not device UI verification.
